### PR TITLE
RBAC now included, using "admin", "editor" & "viewer"

### DIFF
--- a/server/internal/auth/authManager.go
+++ b/server/internal/auth/authManager.go
@@ -9,6 +9,12 @@ type Credentials struct {
 	Password string `json:"password"`
 }
 
+type CreateAccountReq struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Role     string `json:"role"`
+}
+
 type ChangeCredentials struct {
 	OldPassword string `json:"oldPassword"`
 	Password    string `json:"password"`
@@ -21,9 +27,9 @@ type User struct {
 
 type AuthManager interface {
 	InitialiseDatabase(ctx context.Context) error
-	CreateAccount(ctx context.Context, crednetials *Credentials) error
-	Login(ctx context.Context, crednetials *Credentials) (string, error)
-	IsValidLogin(ctx context.Context, token string) (string, error)
+	CreateAccount(ctx context.Context, createAccountReq *CreateAccountReq) error
+	Login(ctx context.Context, credentials *Credentials) (string, error)
+	IsValidLogin(ctx context.Context, token string) (string, string, error)
 	RevokeToken(ctx context.Context, tokenString string) error
 	GetUsers(ctx context.Context, limit, offset int) ([]*User, error)
 	GetUserPageCount(ctx context.Context, limit int) (int, error)

--- a/server/internal/auth/authManager.go
+++ b/server/internal/auth/authManager.go
@@ -12,7 +12,7 @@ type Credentials struct {
 type CreateAccountReq struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
-	Role     string `json:"role"`
+	Role     string `json:"role" enums:"admin,editor,viewer"`
 }
 
 type ChangeCredentials struct {

--- a/server/internal/auth/authManager_test.go
+++ b/server/internal/auth/authManager_test.go
@@ -16,7 +16,7 @@ func test_Setup_AuthManager(t *testing.T, authManager auth.AuthManager) {
 	})
 }
 
-func test_CreateAccount_Valid(t *testing.T, authManager auth.AuthManager, credentials *auth.Credentials) {
+func test_CreateAccount_Valid(t *testing.T, authManager auth.AuthManager, credentials *auth.CreateAccountReq) {
 	t.Run("Success Path create account", func(t *testing.T) {
 		err := authManager.InitialiseDatabase(context.Background())
 		require.NoError(t, err)
@@ -26,7 +26,7 @@ func test_CreateAccount_Valid(t *testing.T, authManager auth.AuthManager, creden
 	})
 }
 
-func test_CreateAccount_UsernameAlreadyExists(t *testing.T, authManager auth.AuthManager, credentials *auth.Credentials) {
+func test_CreateAccount_UsernameAlreadyExists(t *testing.T, authManager auth.AuthManager, credentials *auth.CreateAccountReq) {
 	t.Run("Failed Dup account", func(t *testing.T) {
 		// Create the first account
 		err := authManager.CreateAccount(context.Background(), credentials)
@@ -40,10 +40,15 @@ func test_CreateAccount_UsernameAlreadyExists(t *testing.T, authManager auth.Aut
 
 }
 
-func test_valid_login(t *testing.T, authManager auth.AuthManager, credentials *auth.Credentials) {
+func test_valid_login(t *testing.T, authManager auth.AuthManager, createAccountReq *auth.CreateAccountReq) {
 	t.Run("valid login for account", func(t *testing.T) {
-		err := authManager.CreateAccount(context.Background(), credentials)
+		err := authManager.CreateAccount(context.Background(), createAccountReq)
 		require.NoError(t, err)
+
+		credentials := &auth.Credentials{
+			Username: createAccountReq.Username,
+			Password: createAccountReq.Password,
+		}
 
 		token, err := authManager.Login(context.Background(), credentials)
 		require.NoError(t, err)
@@ -59,26 +64,36 @@ func test_invalid_login(t *testing.T, authManager auth.AuthManager, credentials 
 	})
 }
 
-func test_is_valid_login(t *testing.T, authManager auth.AuthManager, credentials *auth.Credentials) {
+func test_is_valid_login(t *testing.T, authManager auth.AuthManager, createAccountReq *auth.CreateAccountReq) {
 	t.Run("is valid login for account", func(t *testing.T) {
-		err := authManager.CreateAccount(context.Background(), credentials)
+		err := authManager.CreateAccount(context.Background(), createAccountReq)
 		require.NoError(t, err)
+
+		credentials := &auth.Credentials{
+			Username: createAccountReq.Username,
+			Password: createAccountReq.Password,
+		}
 
 		token, err := authManager.Login(context.Background(), credentials)
 		require.NoError(t, err)
 		require.NotEmpty(t, token)
 
-		id, err := authManager.IsValidLogin(context.Background(), token)
+		id, _, err := authManager.IsValidLogin(context.Background(), token)
 		require.NoError(t, err)
 		require.NotEmpty(t, id)
 	})
 }
 
-func test_revoke_token(t *testing.T, authManager auth.AuthManager, credentials *auth.Credentials) {
+func test_revoke_token(t *testing.T, authManager auth.AuthManager, createAccountReq *auth.CreateAccountReq) {
 	t.Run("is valid login and revoke for account", func(t *testing.T) {
 		// Create account and login to get token
-		err := authManager.CreateAccount(context.Background(), credentials)
+		err := authManager.CreateAccount(context.Background(), createAccountReq)
 		require.NoError(t, err)
+
+		credentials := &auth.Credentials{
+			Username: createAccountReq.Username,
+			Password: createAccountReq.Password,
+		}
 
 		token, err := authManager.Login(context.Background(), credentials)
 		require.NoError(t, err)
@@ -89,22 +104,27 @@ func test_revoke_token(t *testing.T, authManager auth.AuthManager, credentials *
 		require.NoError(t, err)
 
 		// Check if the token is invalid after revocation
-		id, err := authManager.IsValidLogin(context.Background(), token)
+		id, _, err := authManager.IsValidLogin(context.Background(), token)
 		require.Error(t, err)
 		require.Empty(t, id)
 	})
 }
 
-func test_change_password(t *testing.T, authManager auth.AuthManager, credentials *auth.Credentials) {
+func test_change_password(t *testing.T, authManager auth.AuthManager, createAccountReq *auth.CreateAccountReq) {
 	t.Run("changing password", func(t *testing.T) {
-		err := authManager.CreateAccount(context.Background(), credentials)
+		err := authManager.CreateAccount(context.Background(), createAccountReq)
 		require.NoError(t, err)
+
+		credentials := &auth.Credentials{
+			Username: createAccountReq.Username,
+			Password: createAccountReq.Password,
+		}
 
 		token, err := authManager.Login(context.Background(), credentials)
 		require.NoError(t, err)
 		require.NotEmpty(t, token)
 
-		id, err := authManager.IsValidLogin(context.Background(), token)
+		id, _, err := authManager.IsValidLogin(context.Background(), token)
 		require.NoError(t, err)
 		require.NotEmpty(t, id)
 
@@ -127,7 +147,7 @@ func test_change_password(t *testing.T, authManager auth.AuthManager, credential
 		require.NoError(t, err)
 		require.NotEmpty(t, token)
 
-		id, err = authManager.IsValidLogin(context.Background(), token)
+		id, _, err = authManager.IsValidLogin(context.Background(), token)
 		require.NoError(t, err)
 		require.NotEmpty(t, id)
 	})

--- a/server/internal/auth/authPostgresManager.go
+++ b/server/internal/auth/authPostgresManager.go
@@ -70,7 +70,7 @@ func (a *authPostgresManager) InitialiseDatabase(ctx context.Context) error {
 	if count == 0 {
 		createDefaultAccountSQL := `
 			INSERT INTO accounts (username, password_hash, role) 
-			VALUES ($1, crypt($2, gen_salt('bf')), 'Admin');
+			VALUES ($1, crypt($2, gen_salt('bf')), 'admin');
 		`
 
 		// TODO: move out adminpassword to a ENV

--- a/server/internal/auth/authSqliteManager.go
+++ b/server/internal/auth/authSqliteManager.go
@@ -69,6 +69,7 @@ func (a *authSqliteManager) InitialiseDatabase(ctx context.Context) error {
 			id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
 			username TEXT UNIQUE NOT NULL,
 			password_hash TEXT NOT NULL,
+			role TEXT NOT NULL DEFAULT 'viewer',
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);
@@ -99,8 +100,8 @@ func (a *authSqliteManager) InitialiseDatabase(ctx context.Context) error {
 	// If the account does not exist, create the default account
 	if count == 0 {
 		createDefaultAccountSQL := `
-			INSERT INTO accounts (username, password_hash) 
-			VALUES (?, ?);
+			INSERT INTO accounts (username, password_hash, role) 
+			VALUES (?, ?, ?);
 		`
 
 		hashedPassword, err := hashPassword("adminpassword")
@@ -108,7 +109,7 @@ func (a *authSqliteManager) InitialiseDatabase(ctx context.Context) error {
 			return err
 		}
 
-		if _, err := a.db.ExecContext(ctx, createDefaultAccountSQL, "admin", hashedPassword); err != nil {
+		if _, err := a.db.ExecContext(ctx, createDefaultAccountSQL, "admin", hashedPassword, "admin"); err != nil {
 			return fmt.Errorf("failed to create default account: %v", err)
 		}
 	}
@@ -164,10 +165,10 @@ func (a *authSqliteManager) ChangePassword(ctx context.Context, username string,
 	return nil
 }
 
-func (a *authSqliteManager) CreateAccount(ctx context.Context, credentials *Credentials) error {
+func (a *authSqliteManager) CreateAccount(ctx context.Context, credentials *CreateAccountReq) error {
 	createAccountSQL := `
-		INSERT INTO accounts (username, password_hash) 
-		VALUES (?, ?);
+		INSERT INTO accounts (username, password_hash, role) 
+		VALUES (?, ?, ?);
 	`
 
 	hashedPassword, err := hashPassword(credentials.Password)
@@ -175,7 +176,7 @@ func (a *authSqliteManager) CreateAccount(ctx context.Context, credentials *Cred
 		return err
 	}
 
-	if _, err := a.db.ExecContext(ctx, createAccountSQL, credentials.Username, hashedPassword); err != nil {
+	if _, err := a.db.ExecContext(ctx, createAccountSQL, credentials.Username, hashedPassword, credentials.Role); err != nil {
 		return fmt.Errorf("failed to create account: %v", err)
 	}
 
@@ -184,7 +185,7 @@ func (a *authSqliteManager) CreateAccount(ctx context.Context, credentials *Cred
 
 func (a *authSqliteManager) DeleteUser(ctx context.Context, user string) error {
 	if user == "admin" {
-		return fmt.Errorf("Cannot delete the admin account")
+		return fmt.Errorf("cannot delete the admin account")
 	}
 
 	if _, err := a.db.ExecContext(ctx, `
@@ -217,7 +218,7 @@ func (a *authSqliteManager) GetUserPageCount(ctx context.Context, limit int) (in
 
 func (a *authSqliteManager) GetUsers(ctx context.Context, limit int, offset int) ([]*User, error) {
 	rows, err := a.db.QueryContext(ctx, `
-	SELECT username
+	SELECT username, role
 	FROM accounts
 	ORDER BY created_at DESC
 	LIMIT ? OFFSET ?;
@@ -232,11 +233,9 @@ func (a *authSqliteManager) GetUsers(ctx context.Context, limit int, offset int)
 	users := []*User{}
 	for rows.Next() {
 		user := User{}
-		if err := rows.Scan(&user.Username); err != nil {
+		if err := rows.Scan(&user.Username, &user.Role); err != nil {
 			return nil, err
 		}
-
-		user.Role = "Admin"
 
 		users = append(users, &user)
 	}
@@ -244,7 +243,7 @@ func (a *authSqliteManager) GetUsers(ctx context.Context, limit int, offset int)
 	return users, nil
 }
 
-func (a *authSqliteManager) IsValidLogin(ctx context.Context, tokenString string) (string, error) {
+func (a *authSqliteManager) IsValidLogin(ctx context.Context, tokenString string) (string, string, error) {
 	// Parse the JWT token
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		// Ensure that the token method is HMAC
@@ -255,7 +254,7 @@ func (a *authSqliteManager) IsValidLogin(ctx context.Context, tokenString string
 	})
 
 	if err != nil || !token.Valid {
-		return "", fmt.Errorf("invalid token")
+		return "", "", fmt.Errorf("invalid token")
 	}
 
 	// Query the token details from the database
@@ -267,14 +266,14 @@ func (a *authSqliteManager) IsValidLogin(ctx context.Context, tokenString string
 		WHERE token = ? AND expires_at > CURRENT_TIMESTAMP;
 	`, tokenString).Scan(&revoked, &accountId); err != nil {
 		if err == sql.ErrNoRows {
-			return "", fmt.Errorf("invalid or expired token")
+			return "", "", fmt.Errorf("invalid or expired token")
 		}
-		return "", fmt.Errorf("failed to query token: %v", err)
+		return "", "", fmt.Errorf("failed to query token: %v", err)
 	}
 
 	// Check if the token has been revoked
 	if revoked {
-		return "", fmt.Errorf("token has been revoked")
+		return "", "", fmt.Errorf("token has been revoked")
 	}
 
 	// Query the username based on account ID
@@ -285,12 +284,12 @@ func (a *authSqliteManager) IsValidLogin(ctx context.Context, tokenString string
 		WHERE id = ?;
 	`, accountId).Scan(&username); err != nil {
 		if err == sql.ErrNoRows {
-			return "", fmt.Errorf("could not find username")
+			return "", "", fmt.Errorf("could not find username")
 		}
-		return "", fmt.Errorf("failed to query for username: %v", err)
+		return "", "", fmt.Errorf("failed to query for username: %v", err)
 	}
 
-	return username, nil
+	return username, "", nil
 }
 
 func (a *authSqliteManager) Login(ctx context.Context, credentials *Credentials) (string, error) {

--- a/server/internal/auth/authSqliteManager_test.go
+++ b/server/internal/auth/authSqliteManager_test.go
@@ -69,7 +69,7 @@ func Test_Sqlite_CreateAccount(t *testing.T) {
 	require.NotEmpty(t, passwordHash)
 
 	createAccountReq = &auth.CreateAccountReq{
-		Username: "testuser",
+		Username: "testuser2",
 		Password: "testpassword",
 	}
 

--- a/server/internal/rest/fuzz_test.go
+++ b/server/internal/rest/fuzz_test.go
@@ -17,9 +17,10 @@ const (
 func FuzzAPIFuzzing(f *testing.F) {
 	f.Fuzz(func(t *testing.T, name, password string) {
 		// Create a new request with the fuzzed input
-		body := auth.Credentials{
+		body := auth.CreateAccountReq{
 			Username: name,
 			Password: password,
+			Role:     "viewer",
 		}
 
 		bBody, err := json.Marshal(body)

--- a/server/internal/rest/middleware.go
+++ b/server/internal/rest/middleware.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"fmt"
 	"kontroler-server/internal/auth"
 	"strings"
 	"time"
@@ -9,6 +10,18 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 )
+
+const (
+	AdminRole  = "admin"
+	EditorRole = "editor"
+	ViewerRole = "viewer"
+)
+
+var roleHierarchy = map[string]int{
+	AdminRole:  3,
+	EditorRole: 2,
+	ViewerRole: 1,
+}
 
 // AuditLoggerMiddleware creates an audit log for each request
 func AuditLoggerMiddleware() fiber.Handler {
@@ -45,13 +58,57 @@ func Authentication(c *fiber.Ctx, authManager auth.AuthManager) error {
 		return c.SendStatus(fiber.StatusUnauthorized)
 	}
 
-	username, err := authManager.IsValidLogin(c.Context(), jwtToken)
+	username, role, err := authManager.IsValidLogin(c.Context(), jwtToken)
 	if err != nil {
 		return c.SendStatus(fiber.StatusUnauthorized)
 	}
 
 	c.Locals("token", jwtToken)
 	c.Locals("username", username)
+	c.Locals("role", role)
 
 	return c.Next()
+}
+
+// roleMiddleware checks if the user has the required role
+func roleMiddleware(requiredRole string) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		userRole := c.Locals("role")
+
+		if userRole == nil {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Unauthorized",
+			})
+		}
+
+		// Convert to strings for role comparison
+		role, ok := userRole.(string)
+		if !ok {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Invalid role",
+			})
+		}
+
+		// Check if the user has the required role or higher
+		if !isRoleGreaterOrEqual(role, requiredRole) {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": fmt.Sprintf("Forbidden: You must have '%s' or higher role", requiredRole),
+			})
+		}
+
+		return c.Next()
+	}
+}
+
+// isRoleGreaterOrEqual compares user role rank with required role rank
+func isRoleGreaterOrEqual(userRole, requiredRole string) bool {
+	userRank, userExists := roleHierarchy[userRole]
+	requiredRank, requiredExists := roleHierarchy[requiredRole]
+
+	// If the role doesn't exist, deny access
+	if !userExists || !requiredExists {
+		return false
+	}
+
+	return userRank >= requiredRank
 }

--- a/server/internal/rest/rest.go
+++ b/server/internal/rest/rest.go
@@ -73,7 +73,7 @@ func CreateTLSConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func ValidateCredentials(req auth.Credentials) error {
+func ValidateCredentials(req auth.CreateAccountReq) error {
 	if len(req.Username) < 3 || len(req.Username) > 100 {
 		return fmt.Errorf("username must be between 3 and 100 characters long")
 	}
@@ -104,6 +104,10 @@ func ValidateCredentials(req auth.Credentials) error {
 
 	if !hasLetter {
 		return fmt.Errorf("password must contain at least one letter")
+	}
+
+	if req.Role != "admin" && req.Role != "editor" && req.Role != "viewer" {
+		return fmt.Errorf("role must be either Admin, editor, or Viewer")
 	}
 
 	return nil

--- a/server/internal/rest/rest.go
+++ b/server/internal/rest/rest.go
@@ -107,7 +107,7 @@ func ValidateCredentials(req auth.CreateAccountReq) error {
 	}
 
 	if req.Role != "admin" && req.Role != "editor" && req.Role != "viewer" {
-		return fmt.Errorf("role must be either Admin, editor, or Viewer")
+		return fmt.Errorf("role must be either admin, editor, or viewer")
 	}
 
 	return nil

--- a/server/internal/rest/rest_test.go
+++ b/server/internal/rest/rest_test.go
@@ -9,62 +9,87 @@ import (
 func TestValidateCredentials(t *testing.T) {
 	tests := []struct {
 		name         string
-		credentials  auth.Credentials
+		credentials  auth.CreateAccountReq
 		expectError  bool
 		errorMessage string
 	}{
 		// Valid cases
 		{
-			name:        "Valid username and password",
-			credentials: auth.Credentials{"ValidUser1", "Password123"},
+			name: "Valid username and password",
+			credentials: auth.CreateAccountReq{
+				Username: "ValidUser1",
+				Password: "Password123",
+				Role:     "viewer"},
 			expectError: false,
 		},
 		{
-			name:        "Valid length",
-			credentials: auth.Credentials{"AReallyLongUsernameThatLessThaCharsLongWhichIsValid12345", "ValidPassword123"},
+			name: "Valid length",
+			credentials: auth.CreateAccountReq{
+				Username: "AReallyLongUsernameThatLessThaCharsLongWhichIsValid12345",
+				Password: "ValidPassword123",
+				Role:     "viewer"},
 			expectError: false,
 		},
 
 		// Invalid username cases
 		{
 			name:         "Username too short",
-			credentials:  auth.Credentials{"ab", "ValidPassword123"},
+			credentials:  auth.CreateAccountReq{Username: "ab", Password: "ValidPassword123", Role: "viewer"},
 			expectError:  true,
 			errorMessage: "username must be between 3 and 100 characters long",
 		},
 		{
-			name:         "Username too long",
-			credentials:  auth.Credentials{"ThisIsAVeryLongUsernameThatExceedsOneHundredCharactersAndIsUsedToTestTheUsernameValidationHskajdklsajdj", "ValidPassword123"},
+			name: "Username too long",
+			credentials: auth.CreateAccountReq{
+				Username: "ThisIsAVeryLongUsernameThatExceedsOneHundredCharactersAndIsUsedToTestTheUsernameValidationHskajdklsajdj",
+				Password: "ValidPassword123",
+				Role:     "viewer",
+			},
 			expectError:  true,
 			errorMessage: "username must be between 3 and 100 characters long",
 		},
 		{
-			name:         "Username starts with a number",
-			credentials:  auth.Credentials{"1InvalidUser", "Password123"},
+			name: "Username starts with a number",
+			credentials: auth.CreateAccountReq{
+				Username: "1InvalidUser",
+				Password: "Password123",
+				Role:     "viewer"},
 			expectError:  true,
 			errorMessage: "username must start with a letter",
 		},
 		{
-			name:         "Username contains invalid characters",
-			credentials:  auth.Credentials{"Invalid@User", "Password123"},
+			name: "Username contains invalid characters",
+			credentials: auth.CreateAccountReq{
+				Username: "Invalid@User",
+				Password: "Password123",
+				Role:     "viewer"},
 			expectError:  true,
 			errorMessage: "username must use only letter or number characters",
 		},
 		{
-			name:         "Password too short",
-			credentials:  auth.Credentials{"ValidUser", "short"},
+			name: "Password too short",
+			credentials: auth.CreateAccountReq{
+				Username: "ValidUser",
+				Password: "short",
+				Role:     "viewer"},
 			expectError:  true,
 			errorMessage: "password must be at least 8 characters long",
 		},
 		{
-			name:         "Password without letters",
-			credentials:  auth.Credentials{"ValidUser", "12345678"},
+			name: "Password without letters",
+			credentials: auth.CreateAccountReq{
+				Username: "ValidUser",
+				Password: "12345678",
+				Role:     "viewer"},
 			expectError:  true,
 			errorMessage: "password must contain at least one letter",
 		},
 		{
-			name:         "Password contains invalid characters",
-			credentials:  auth.Credentials{"ValidUser", "Invalid@Password"},
+			name: "Password contains invalid characters",
+			credentials: auth.CreateAccountReq{
+				Username: "ValidUser",
+				Password: "Invalid@Password",
+				Role:     "viewer"},
 			expectError:  true,
 			errorMessage: "password must use only letter or number characters",
 		},

--- a/server/internal/rest/rest_test.go
+++ b/server/internal/rest/rest_test.go
@@ -93,6 +93,24 @@ func TestValidateCredentials(t *testing.T) {
 			expectError:  true,
 			errorMessage: "password must use only letter or number characters",
 		},
+		{
+			name: "Invalid role",
+			credentials: auth.CreateAccountReq{
+				Username: "ValidUser",
+				Password: "ValidPassword123",
+				Role:     "invalid_role"},
+			expectError:  true,
+			errorMessage: "role must be either admin, editor, or viewer",
+		},
+		{
+			name: "Empty role",
+			credentials: auth.CreateAccountReq{
+				Username: "ValidUser",
+				Password: "ValidPassword123",
+				Role:     ""},
+			expectError:  true,
+			errorMessage: "role must be either admin, editor, or viewer",
+		},
 	}
 
 	for _, test := range tests {

--- a/server/internal/rest/v1.go
+++ b/server/internal/rest/v1.go
@@ -31,7 +31,7 @@ func addV1(app *fiber.App, dbManager db.DbManager, kubClient dynamic.Interface, 
 func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Interface) {
 	dagRouter := router.Group("/dag")
 
-	dagRouter.Get("/names", func(c *fiber.Ctx) error {
+	dagRouter.Get("/names", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		term := c.Query("term")
 		if term == "" {
 			return c.SendStatus(fiber.StatusBadRequest)
@@ -48,7 +48,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		})
 	})
 
-	dagRouter.Get("/parameters", func(c *fiber.Ctx) error {
+	dagRouter.Get("/parameters", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		name := c.Query("name")
 		if name == "" {
 			return c.SendStatus(fiber.StatusBadRequest)
@@ -65,7 +65,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		})
 	})
 
-	dagRouter.Get("/meta/:page", func(c *fiber.Ctx) error {
+	dagRouter.Get("/meta/:page", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		page, err := strconv.Atoi(c.Params("page"))
 		if err != nil {
 			return c.SendStatus(fiber.StatusBadRequest)
@@ -86,7 +86,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		})
 	})
 
-	dagRouter.Get("/pages/count", func(c *fiber.Ctx) error {
+	dagRouter.Get("/pages/count", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		pageCount, err := dbManager.GetDagPageCount(c.Context(), 10)
 		if err != nil {
 			log.Error().Err(err).Msg("Error getting dag page count")
@@ -98,7 +98,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		})
 	})
 
-	dagRouter.Get("/runs/:page", func(c *fiber.Ctx) error {
+	dagRouter.Get("/runs/:page", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		page, err := strconv.Atoi(c.Params("page"))
 		if err != nil {
 			return c.SendStatus(fiber.StatusBadRequest)
@@ -117,7 +117,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		return c.Status(fiber.StatusOK).JSON(dags)
 	})
 
-	dagRouter.Get("/run/:id", func(c *fiber.Ctx) error {
+	dagRouter.Get("/run/:id", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		id, err := strconv.Atoi(c.Params("id"))
 		if err != nil {
 			return c.SendStatus(fiber.StatusBadRequest)
@@ -132,7 +132,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		return c.Status(fiber.StatusOK).JSON(dagRun)
 	})
 
-	dagRouter.Get("/run/all/:id", func(c *fiber.Ctx) error {
+	dagRouter.Get("/run/all/:id", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		id, err := strconv.Atoi(c.Params("id"))
 		if err != nil {
 			return c.SendStatus(fiber.StatusBadRequest)
@@ -147,7 +147,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		return c.Status(fiber.StatusOK).JSON(dagRun)
 	})
 
-	dagRouter.Get("/run/task/:runId/:taskId", func(c *fiber.Ctx) error {
+	dagRouter.Get("/run/task/:runId/:taskId", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		runId, err := strconv.Atoi(c.Params("runId"))
 		if err != nil {
 			return c.SendStatus(fiber.StatusBadRequest)
@@ -167,7 +167,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		return c.Status(fiber.StatusOK).JSON(taskDetails)
 	})
 
-	dagRouter.Get("/task/:taskId", func(c *fiber.Ctx) error {
+	dagRouter.Get("/task/:taskId", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		taskId, err := strconv.Atoi(c.Params("taskId"))
 		if err != nil {
 			return c.SendStatus(fiber.StatusBadRequest)
@@ -182,7 +182,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		return c.Status(fiber.StatusOK).JSON(taskDetails)
 	})
 
-	dagRouter.Get("/dagTask/pages/page/:page", func(c *fiber.Ctx) error {
+	dagRouter.Get("/dagTask/pages/page/:page", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		page, err := strconv.Atoi(c.Params("page"))
 		if err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -204,7 +204,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		return c.Status(fiber.StatusOK).JSON(taskDetails)
 	})
 
-	dagRouter.Get("/dagTask/pages/count", func(c *fiber.Ctx) error {
+	dagRouter.Get("/dagTask/pages/count", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		pageCount, err := dbManager.GetDagTaskPageCount(c.Context(), 10)
 		if err != nil {
 			log.Error().Err(err).Msg("Error getting DagTask details")
@@ -216,7 +216,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		})
 	})
 
-	dagRouter.Post("/create", func(c *fiber.Ctx) error {
+	dagRouter.Post("/create", roleMiddleware("editor"), func(c *fiber.Ctx) error {
 		var dagForm kclient.DagFormObj
 		if err := c.BodyParser(&dagForm); err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -237,7 +237,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 
 	})
 
-	dagRouter.Get("/run/pages/count", func(c *fiber.Ctx) error {
+	dagRouter.Get("/run/pages/count", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		pageCount, err := dbManager.GetDagRunPageCount(c.Context(), 10)
 		if err != nil {
 			log.Error().Err(err).Msg("Error getting dag run page count")
@@ -249,7 +249,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 		})
 	})
 
-	dagRouter.Post("/run/create", func(c *fiber.Ctx) error {
+	dagRouter.Post("/run/create", roleMiddleware("editor"), func(c *fiber.Ctx) error {
 		var dagrunForm kclient.DagRunForm
 		if err := c.BodyParser(&dagrunForm); err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -287,7 +287,7 @@ func addDags(router fiber.Router, dbManager db.DbManager, kubClient dynamic.Inte
 func addStats(router fiber.Router, dbManager db.DbManager) {
 	statsRouter := router.Group("/stats")
 
-	statsRouter.Get("/dashboard", func(c *fiber.Ctx) error {
+	statsRouter.Get("/dashboard", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		stats, err := dbManager.GetDashboardStats(c.Context())
 		if err != nil {
 			log.Error().Err(err).Msg("Error getting main stats")
@@ -333,8 +333,8 @@ func addAccountAuth(router fiber.Router, authManager auth.AuthManager) {
 			"message": "Login successful",
 		})
 	})
-	authRouter.Post("/create", func(c *fiber.Ctx) error {
-		var req auth.Credentials
+	authRouter.Post("/create", roleMiddleware("admin"), func(c *fiber.Ctx) error {
+		var req auth.CreateAccountReq
 		if err := c.BodyParser(&req); err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 				"message": err.Error(),
@@ -390,7 +390,7 @@ func addAccountAuth(router fiber.Router, authManager auth.AuthManager) {
 			return c.SendStatus(fiber.StatusUnauthorized)
 		}
 
-		username, err := authManager.IsValidLogin(c.Context(), jwtToken)
+		username, _, err := authManager.IsValidLogin(c.Context(), jwtToken)
 		if err != nil {
 			return c.SendStatus(fiber.StatusUnauthorized)
 		}
@@ -400,7 +400,7 @@ func addAccountAuth(router fiber.Router, authManager auth.AuthManager) {
 		})
 	})
 
-	authRouter.Get("/users/page/:page", func(c *fiber.Ctx) error {
+	authRouter.Get("/users/page/:page", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		page, err := strconv.Atoi(c.Params("page"))
 		if err != nil {
 			return c.SendStatus(fiber.StatusBadRequest)
@@ -420,7 +420,7 @@ func addAccountAuth(router fiber.Router, authManager auth.AuthManager) {
 		})
 	})
 
-	authRouter.Get("/users/pages/count", func(c *fiber.Ctx) error {
+	authRouter.Get("/users/pages/count", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		pageCount, err := authManager.GetUserPageCount(c.Context(), 10)
 		if err != nil {
 			log.Error().Err(err).Msg("Error getting user page count")
@@ -432,7 +432,7 @@ func addAccountAuth(router fiber.Router, authManager auth.AuthManager) {
 		})
 	})
 
-	authRouter.Delete("/users/:user", func(c *fiber.Ctx) error {
+	authRouter.Delete("/users/:user", roleMiddleware("admin"), func(c *fiber.Ctx) error {
 		user := c.Params("user")
 		if user == "" {
 			return c.SendStatus(fiber.StatusBadRequest)
@@ -456,7 +456,7 @@ func addAccountAuth(router fiber.Router, authManager auth.AuthManager) {
 func addLogs(router fiber.Router, logFetcher logs.LogFetcher) {
 	logRouter := router.Group("/logs")
 
-	logRouter.Get("/run/:run/pod/:pod", func(c *fiber.Ctx) error {
+	logRouter.Get("/run/:run/pod/:pod", roleMiddleware("viewer"), func(c *fiber.Ctx) error {
 		podName := c.Params("pod")
 		if podName == "" {
 			return c.SendStatus(fiber.StatusBadRequest)

--- a/ui/src/api/admin.ts
+++ b/ui/src/api/admin.ts
@@ -34,6 +34,7 @@ class AccountError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'AccountError';
+    Object.setPrototypeOf(this, AccountError.prototype);
   }
 }
 

--- a/ui/src/api/admin.ts
+++ b/ui/src/api/admin.ts
@@ -30,20 +30,49 @@ export async function getUserPageCount(): Promise<number> {
   return result.data.count;
 }
 
+class AccountError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AccountError';
+  }
+}
+
 export async function createAccount(
   username: string,
-  password: string
+  password: string,
+  role: string,
 ): Promise<void> {
-  await axios.post(
-    `${getApiUrl()}/api/v1/auth/create`,
-    {
-      username,
-      password,
-    },
-    {
-      withCredentials: true,
+  try {
+    await axios.post(
+      `${getApiUrl()}/api/v1/auth/create`,
+      {
+        username,
+        password,
+        role,
+      },
+      {
+        withCredentials: true,
+      }
+    );
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      switch (error.response?.status) {
+        case 400:
+          throw new AccountError('Invalid username or password format.');
+        case 401:
+          throw new AccountError('Authentication required. Please log in.');
+        case 403:
+          throw new AccountError('You do not have permission to create accounts, must be an Admin');
+        case 409:
+          throw new AccountError(`Username '${username}' already exists.`);
+        case 500:
+          throw new AccountError('Server error occurred while creating account.');
+        default:
+          throw new AccountError(error.message || 'Failed to create account.');
+      }
     }
-  );
+    throw new AccountError('Network error occurred while creating account.');
+  }
 }
 
 export async function deleteAccount(username: string): Promise<void> {

--- a/ui/src/components/DagRunForm.tsx
+++ b/ui/src/components/DagRunForm.tsx
@@ -89,7 +89,7 @@ export default function DagRunForm() {
         setSuccessMsg("DagRun was created!");
       })
       .catch((e) => {
-        setErrorMsgs(["failed to create DagRun"]);
+        setErrorMsgs([e.message]);
       });
   };
 

--- a/ui/src/pages/createAccount.tsx
+++ b/ui/src/pages/createAccount.tsx
@@ -10,6 +10,7 @@ export default function CreateAccountPage() {
   const [username, setUsername] = createSignal<string>("");
   const [password, setPassword] = createSignal<string>("");
   const [passwordConfirm, setPasswordConfirm] = createSignal<string>("");
+  const [role, setRole] = createSignal<string>("");
 
   const onSubmit = () => {
     setErrorMsgs([]);
@@ -27,17 +28,21 @@ export default function CreateAccountPage() {
       errors.push("passwords must match");
     }
 
+    if (["admin", "editor", "viewer"].indexOf(role()) === -1) {
+      errors.push("role must be either Admin, Editor, or Viewer");
+    }
+
     if (errors.length != 0) {
       setErrorMsgs(errors);
       return;
     }
 
-    createAccount(username(), password())
+    createAccount(username(), password(), role())
       .then(() => {
         setSuccessMsg("Account has been successfully created!");
       })
-      .catch(() => {
-        setErrorMsgs(["failed to create the new user"]);
+      .catch((e) => {
+        setErrorMsgs([e.message]);
       });
   };
 
@@ -80,6 +85,23 @@ export default function CreateAccountPage() {
                 setPasswordConfirm(event.currentTarget.value);
               }}
             />
+          </div>
+          <div>
+            <label class="block text-lg font-medium my-4">
+              Role
+            </label>
+            <select
+              class="mt-1 block w-full px-3 py-2 border border-gray-600 bg-gray-700 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm text-gray-200"
+              required
+              onChange={(event) => {
+                setRole(event.currentTarget.value.toLowerCase());
+              }}
+            >
+              <option value="">Select a role</option>
+              <option value="admin">Admin</option>
+              <option value="editor">Editor</option>
+              <option value="viewer">Viewer</option>
+            </select>
           </div>
 
           <div class="flex justify-center">


### PR DESCRIPTION
These are abroad RBAC roles and are used to define which users can hit which endpoints in the server. Roles do not determine who can create objects with kubernetes access.

UI slightly updated to add roles to form & basic improvements to error handling for two of the forms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled account creation with role selection, allowing users to be designated as admin, editor, or viewer.
  - Introduced role-based access controls to secure sensitive operations on various endpoints.

- **Enhancements**
  - Improved error handling across account creation and DAG run actions, providing more informative feedback.
  - Strengthened validation of user input to ensure the correct role is selected, resulting in clearer error messages for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->