### PR TITLE
Optimize controller behavior and enhance DSL hash testing

### DIFF
--- a/controller/README.md
+++ b/controller/README.md
@@ -79,6 +79,81 @@ make test
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 
+## Defaults and local testing notes
+
+This project ships a small set of defaults and conveniences to make local
+and CI testing straightforward. Below are the most important defaults and
+how to override them for production.
+
+- Configuration file (configpath):
+  - If the manager is started without the `--configpath` flag or an
+    external config file, the binary will use a sensible built-in default
+    configuration (memory-based workers, a single default namespace watcher,
+    and a filesystem log store at `/tmp/kontroler-logs`). This is intended
+    to make local e2e and dev runs easier. For production, supply a full
+    YAML config and pass `--configpath` to the manager.
+
+- Database selection and defaults:
+  - DB_TYPE: must be set to either `postgresql` or `sqlite`.
+  - For local tests and single-node deployments use `sqlite`.
+  - When using `sqlite` set `SQLITE_PATH` (for tests you can use `:memory:`).
+  - When using `postgresql` set `DB_NAME`, `DB_USER`, `DB_ENDPOINT`, and
+    `DB_PASSWORD` and optionally `DB_SSL_MODE`.
+
+- Concurrency tuning:
+  - Bounded concurrency for background batch operations is controlled by a
+    package-level constant `defaultConcurrency` (set to 8). Change this
+    value in `internal/controller/dag_controller.go` if you need a higher
+    or lower bound when adding/removing finalizers or deleting pods.
+
+- Webhooks and cert-manager:
+  - The operator's webhook requires a TLS certificate. The repository's
+    default manifests include integration points for cert-manager to issue
+    the webhook certs via an Issuer/Certificate resource.
+  - In local e2e runs ensure cert-manager is installed and its webhook
+    deployment is Healthy before applying the operator manifests. The
+    e2e scripts install cert-manager (see `test/e2e`) but in CI you should
+    also ensure it is available.
+
+- Image handling for Kind/local testing:
+  - To run the e2e test locally you typically build the image and load it
+    into the Kind cluster:
+    - make docker-build IMG=example.com/operator:vX.Y.Z
+    - kind load docker-image example.com/operator:vX.Y.Z --name kind
+  - The deployment imagePullPolicy in the config is set to `IfNotPresent`
+    to favour local `kind load` usage. For production set an appropriate
+    policy (for immutable tags `IfNotPresent` is fine; for moving tags use
+    `Always`).
+
+- Common environment variables used by the deployment (config/manager/manager.yaml):
+  - DB_TYPE (sqlite|postgresql)
+  - SQLITE_PATH (e.g. `:memory:` for tests)
+  - LEADER_ELECTION_ID (defaults to `kontroler` when not provided and no config)
+  - LOG_DIR (when using filesystem log store — defaults to `/tmp/kontroler-logs` in the built-in config)
+
+Running local e2e (quick checklist)
+
+1. Build the manager image and load it into Kind:
+   - make docker-build IMG=example.com/operator:v0.0.1
+   - kind load docker-image example.com/operator:v0.0.1 --name kind
+
+2. Install CRDs and (optionally) cert-manager:
+   - make install
+   - kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
+   - kubectl -n cert-manager wait deployment.apps/cert-manager-webhook --for condition=Available --timeout=5m
+
+3. Deploy the manager with the loaded image:
+   - make deploy IMG=example.com/operator:v0.0.1
+
+4. Verify operator pods are Running:
+   - kubectl -n operator-system get pods
+   - kubectl -n operator-system describe pod <pod> (if Pending / CrashLoopBackOff)
+
+If you want these defaults changed (for example, move the built-in config
+into a mounted ConfigMap, or require an explicit configpath) tell me and I
+can either make the code require a configpath or add a sample config and
+update the deployment to mount it.
+
 ## License
 
 Copyright 2024.

--- a/controller/README.md
+++ b/controller/README.md
@@ -139,7 +139,8 @@ Running local e2e (quick checklist)
 
 2. Install CRDs and (optionally) cert-manager:
    - make install
-   - kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
+   - For cert-manager installation follow the official docs: https://cert-manager.io/docs/installation/
+    (or use the latest release manifest: https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml)
    - kubectl -n cert-manager wait deployment.apps/cert-manager-webhook --for condition=Available --timeout=5m
 
 3. Deploy the manager with the loaded image:
@@ -149,10 +150,10 @@ Running local e2e (quick checklist)
    - kubectl -n operator-system get pods
    - kubectl -n operator-system describe pod <pod> (if Pending / CrashLoopBackOff)
 
-If you want these defaults changed (for example, move the built-in config
-into a mounted ConfigMap, or require an explicit configpath) tell me and I
-can either make the code require a configpath or add a sample config and
-update the deployment to mount it.
+> **NOTE**: To change the built-in defaults you can mount a ConfigMap with a
+> full config file and pass `--configpath` to the manager, or open a PR/issue
+> to update the repository defaults. This keeps runtime behaviour explicit for
+> production deployments.
 
 ## License
 

--- a/controller/cmd/controller/main.go
+++ b/controller/cmd/controller/main.go
@@ -285,7 +285,9 @@ func main() {
 
 		defer dbConn.Close()
 	default:
-		setupLog.Error(err, "unsupported DAG manager provided, 'postgresql' or 'sqlite'")
+		dbType := os.Getenv("DB_TYPE")
+		setupErr := fmt.Errorf("unsupported DAG manager provided, must be 'postgresql' or 'sqlite' (DB_TYPE=%q)", dbType)
+		setupLog.Error(setupErr, "unsupported DAG manager provided")
 		os.Exit(1)
 	}
 

--- a/controller/cmd/controller/main.go
+++ b/controller/cmd/controller/main.go
@@ -150,10 +150,37 @@ func main() {
 		TLSOpts: tlsOpts,
 	})
 
-	configController, err := config.ParseConfig(configPath)
-	if err != nil {
-		setupLog.Error(err, "failed to parse config")
-		os.Exit(1)
+	var configController *config.ControllerConfig
+	var err error
+	if configPath == "" {
+		// Provide a sensible default config for in-cluster / test runs when no configpath
+		configController = &config.ControllerConfig{
+			LeaderElectionID: os.Getenv("LEADER_ELECTION_ID"),
+			Workers: config.WorkerConfigs{
+				WorkerType:   "memory",
+				PollDuration: "100ms",
+				Workers: []config.WorkerConfig{{
+					Namespace: "default",
+					Count:     1,
+				}},
+			},
+			LogStore: config.LogStore{
+				StoreType: "filesystem",
+				FileSystem: config.FileSystemLogStoreConfig{
+					BaseDir: "/tmp/kontroler-logs",
+				},
+			},
+		}
+		// Ensure LEADER_ELECTION_ID has a default
+		if configController.LeaderElectionID == "" {
+			configController.LeaderElectionID = "kontroler"
+		}
+	} else {
+		configController, err = config.ParseConfig(configPath)
+		if err != nil {
+			setupLog.Error(err, "failed to parse config")
+			os.Exit(1)
+		}
 	}
 
 	// Create map of unique namespaces from worker configs

--- a/controller/config/default/manager_auth_proxy_patch.yaml
+++ b/controller/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/controller/config/manager/kustomization.yaml
+++ b/controller/config/manager/kustomization.yaml
@@ -2,6 +2,8 @@ resources:
 - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+  # REPLACE_ME: set to your registry/image, e.g. registry.example.com/operator
+  # REPLACE_ME: set to a proper release tag, e.g. v1.2.3
 images:
 - name: controller
   newName: example.com/operator

--- a/controller/config/manager/kustomization.yaml
+++ b/controller/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: greedykomodo/kontroler-controller
-  newTag: 0.0.1
+  newName: example.com/operator
+  newTag: v0.0.1

--- a/controller/config/manager/manager.yaml
+++ b/controller/config/manager/manager.yaml
@@ -77,7 +77,9 @@ spec:
         - name: DB_TYPE
           value: sqlite
         - name: SQLITE_PATH
-          value: ":memory:"
+          # Use a persistent path in production. ":memory:" is suitable only for tests.
+          value: "/data/kontroler.db"
+        # PostgreSQL-related envs should be supplied via a Secret in production.
         - name: DB_NAME
           value: kubeconductor
         - name: DB_USER
@@ -85,7 +87,10 @@ spec:
         - name: DB_ENDPOINT
           value: my-release-postgresql.default.svc.cluster.local:5432
         - name: DB_PASSWORD
-          value: 
+          valueFrom:
+            secretKeyRef:
+              name: kontroler-db-secret
+              key: password
         - name: JOB_TTL
           value: "180"
         securityContext:

--- a/controller/config/manager/manager.yaml
+++ b/controller/config/manager/manager.yaml
@@ -71,7 +71,7 @@ spec:
         args:
         - --leader-elect
         image: controller:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         env:
         - name: DB_NAME

--- a/controller/config/manager/manager.yaml
+++ b/controller/config/manager/manager.yaml
@@ -74,6 +74,10 @@ spec:
         imagePullPolicy: IfNotPresent
         name: manager
         env:
+        - name: DB_TYPE
+          value: sqlite
+        - name: SQLITE_PATH
+          value: ":memory:"
         - name: DB_NAME
           value: kubeconductor
         - name: DB_USER

--- a/controller/internal/controller/dag_controller.go
+++ b/controller/internal/controller/dag_controller.go
@@ -45,6 +45,9 @@ type DAGReconciler struct {
 	DbManager db.DBDAGManager
 }
 
+// defaultConcurrency controls bounded parallelism for batch operations in controllers
+const defaultConcurrency = 8
+
 //+kubebuilder:rbac:groups=kontroler.greedykomodo,resources=dags,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kontroler.greedykomodo,resources=dags/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kontroler.greedykomodo,resources=dags/finalizers,verbs=update
@@ -63,7 +66,7 @@ func (r *DAGReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	var dag kontrolerv1alpha1.DAG
 	if err := r.Get(ctx, req.NamespacedName, &dag); err != nil {
 		if errors.IsNotFound(err) {
-			return r.handleDeletion(ctx, req, dag)
+			return r.handleDeletion(ctx, req.NamespacedName)
 		}
 		return ctrl.Result{}, err
 	}
@@ -73,7 +76,7 @@ func (r *DAGReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	// Check if the DAG is marked for deletion
 	if !dag.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.handleDeletion(ctx, req, dag)
+		return r.handleDeletion(ctx, req.NamespacedName)
 	}
 
 	// Process DSL if provided. Only do work when the DSL has changed (hash-based).
@@ -197,7 +200,7 @@ func (r *DAGReconciler) updatingDagTaskFinalisers(ctx context.Context, taskRefs 
 	}
 
 	// bounded concurrency
-	const concurrency = 8
+	const concurrency = defaultConcurrency
 	sem := make(chan struct{}, concurrency)
 	g, gctx := errgroup.WithContext(ctx)
 
@@ -240,7 +243,7 @@ func (r *DAGReconciler) removingDagTaskFinalisers(ctx context.Context, taskRefs 
 		return
 	}
 
-	const concurrency = 8
+	const concurrency = defaultConcurrency
 	sem := make(chan struct{}, concurrency)
 	g, gctx := errgroup.WithContext(ctx)
 
@@ -276,24 +279,32 @@ func (r *DAGReconciler) removingDagTaskFinalisers(ctx context.Context, taskRefs 
 	_ = g.Wait()
 }
 
-func (r *DAGReconciler) handleDeletion(ctx context.Context, req ctrl.Request, dag kontrolerv1alpha1.DAG) (ctrl.Result, error) {
+func (r *DAGReconciler) handleDeletion(ctx context.Context, namespacedName types.NamespacedName) (ctrl.Result, error) {
 	// The DAG is being deleted, remove it from the database
-	taskNames, err := r.deleteFromDatabase(ctx, req.NamespacedName)
+	taskNames, err := r.deleteFromDatabase(ctx, namespacedName)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	// Remove the finalizer if it exists
-	if controllerutil.ContainsFinalizer(&dag, "dag.finalizer.kontroler.greedykomodo") {
-		controllerutil.RemoveFinalizer(&dag, "dag.finalizer.kontroler.greedykomodo")
-		old := dag.DeepCopy()
-		if err := r.Patch(ctx, &dag, client.MergeFrom(old)); err != nil {
-			log.Log.Error(err, "failed to remove finalizer from dag", "dag", dag.Name)
-			return ctrl.Result{}, err
+	// Try to fetch the DAG in order to remove its finalizer if present. If the object
+	// is already gone, skip the finalizer removal step.
+	var dag kontrolerv1alpha1.DAG
+	if err := r.Get(ctx, namespacedName, &dag); err == nil {
+		// Remove the finalizer if it exists
+		if controllerutil.ContainsFinalizer(&dag, "dag.finalizer.kontroler.greedykomodo") {
+			controllerutil.RemoveFinalizer(&dag, "dag.finalizer.kontroler.greedykomodo")
+			old := dag.DeepCopy()
+			if err := r.Patch(ctx, &dag, client.MergeFrom(old)); err != nil {
+				log.Log.Error(err, "failed to remove finalizer from dag", "dag", dag.Name)
+				return ctrl.Result{}, err
+			}
 		}
+	} else if !errors.IsNotFound(err) {
+		// If we got an error other than NotFound when fetching the DAG, return it
+		return ctrl.Result{}, err
 	}
 
-	r.removingDagTaskFinalisers(ctx, taskNames, req.Namespace)
+	r.removingDagTaskFinalisers(ctx, taskNames, namespacedName.Namespace)
 
 	return ctrl.Result{}, nil
 }

--- a/controller/internal/controller/dag_controller.go
+++ b/controller/internal/controller/dag_controller.go
@@ -23,6 +23,7 @@ import (
 	sterrors "errors"
 	"fmt"
 
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -191,58 +192,88 @@ func (r *DAGReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *DAGReconciler) updatingDagTaskFinalisers(ctx context.Context, taskRefs []kontrolerv1alpha1.TaskRef, namespace string) {
-	for _, taskRef := range taskRefs {
-		var dagTask kontrolerv1alpha1.DagTask
-		if err := r.Get(ctx, types.NamespacedName{
-			Name:      taskRef.Name,
-			Namespace: namespace,
-		}, &dagTask); err != nil {
-			// Log the error and continue
-			log.Log.Error(err, "failed to fetch dagTask", "taskRef", taskRef)
-			continue
-		}
-
-		if !controllerutil.ContainsFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo") {
-			if updated := controllerutil.AddFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo"); !updated {
-				log.Log.Error(fmt.Errorf("AddFinalizer failed"), "failed to add finalizer to dagTask", "taskRef", taskRef)
-				continue
-			}
-
-			old := dagTask.DeepCopy()
-			if err := r.Patch(ctx, &dagTask, client.MergeFrom(old)); err != nil {
-				log.Log.Error(err, "failed to add finalizer to dagTask", "taskRef", taskRef)
-			}
-		}
+	if len(taskRefs) == 0 {
+		return
 	}
+
+	// bounded concurrency
+	const concurrency = 8
+	sem := make(chan struct{}, concurrency)
+	g, gctx := errgroup.WithContext(ctx)
+
+	for _, tr := range taskRefs {
+		tr := tr // capture
+		sem <- struct{}{}
+		g.Go(func() error {
+			defer func() { <-sem }()
+
+			var dagTask kontrolerv1alpha1.DagTask
+			if err := r.Get(gctx, types.NamespacedName{Name: tr.Name, Namespace: namespace}, &dagTask); err != nil {
+				log.Log.Error(err, "failed to fetch dagTask", "taskRef", tr)
+				return nil
+			}
+
+			if !controllerutil.ContainsFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo") {
+				if updated := controllerutil.AddFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo"); !updated {
+					log.Log.Error(fmt.Errorf("AddFinalizer failed"), "failed to add finalizer to dagTask", "taskRef", tr)
+					return nil
+				}
+
+				old := dagTask.DeepCopy()
+				if err := r.Patch(gctx, &dagTask, client.MergeFrom(old)); err != nil {
+					log.Log.Error(err, "failed to add finalizer to dagTask", "taskRef", tr)
+				}
+			}
+
+			return nil
+		})
+	}
+
+	// wait for all goroutines
+	_ = g.Wait()
 }
 
 func (r *DAGReconciler) removingDagTaskFinalisers(ctx context.Context, taskRefs []string, namespace string) {
 	log.Log.Info("reconcile deletion", "controller", "dag", "namespace", namespace, "method", "removingDagTaskFinalisers", "taskCount", len(taskRefs))
 
-	for _, taskRef := range taskRefs {
-		var dagTask kontrolerv1alpha1.DagTask
-		if err := r.Get(ctx, types.NamespacedName{
-			Name:      taskRef,
-			Namespace: namespace,
-		}, &dagTask); err != nil {
-			// Log the error and continue
-			log.Log.Error(err, "failed to fetch dagTask", "taskRef", taskRef)
-			continue
-		}
-
-		if controllerutil.ContainsFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo") {
-
-			if updated := controllerutil.RemoveFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo"); !updated {
-				log.Log.Error(fmt.Errorf("RemoveFinalizer failed"), "failed to remove finalizer to dagTask", "taskRef", taskRef)
-				continue
-			}
-
-			old := dagTask.DeepCopy()
-			if err := r.Patch(ctx, &dagTask, client.MergeFrom(old)); err != nil {
-				log.Log.Error(err, "failed to remove finalizer from dagTask", "taskRef", taskRef)
-			}
-		}
+	if len(taskRefs) == 0 {
+		return
 	}
+
+	const concurrency = 8
+	sem := make(chan struct{}, concurrency)
+	g, gctx := errgroup.WithContext(ctx)
+
+	for _, tr := range taskRefs {
+		tr := tr
+		sem <- struct{}{}
+		g.Go(func() error {
+			defer func() { <-sem }()
+
+			var dagTask kontrolerv1alpha1.DagTask
+			if err := r.Get(gctx, types.NamespacedName{Name: tr, Namespace: namespace}, &dagTask); err != nil {
+				log.Log.Error(err, "failed to fetch dagTask", "taskRef", tr)
+				return nil
+			}
+
+			if controllerutil.ContainsFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo") {
+
+				if updated := controllerutil.RemoveFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo"); !updated {
+					log.Log.Error(fmt.Errorf("RemoveFinalizer failed"), "failed to remove finalizer to dagTask", "taskRef", tr)
+					return nil
+				}
+
+				old := dagTask.DeepCopy()
+				if err := r.Patch(gctx, &dagTask, client.MergeFrom(old)); err != nil {
+					log.Log.Error(err, "failed to remove finalizer from dagTask", "taskRef", tr)
+				}
+			}
+
+			return nil
+		})
+	}
+
+	_ = g.Wait()
 }
 
 func (r *DAGReconciler) handleDeletion(ctx context.Context, req ctrl.Request, dag kontrolerv1alpha1.DAG) (ctrl.Result, error) {

--- a/controller/internal/controller/dag_controller.go
+++ b/controller/internal/controller/dag_controller.go
@@ -138,9 +138,16 @@ func (r *DAGReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 }
 
 func (r *DAGReconciler) markDAGFailed(ctx context.Context, dag *kontrolerv1alpha1.DAG, reason string) (ctrl.Result, error) {
+	// Avoid unnecessary updates
+	if dag.Status.Phase == "Failed" && dag.Status.Message == reason {
+		log.Log.Info("DAG already marked as failed", "dag", dag.Name)
+		return ctrl.Result{}, nil
+	}
+
+	old := dag.DeepCopy()
 	dag.Status.Phase = "Failed"
 	dag.Status.Message = reason
-	if err := r.Status().Update(ctx, dag); err != nil {
+	if err := r.Status().Patch(ctx, dag, client.MergeFrom(old)); err != nil {
 		log.Log.Error(err, "failed to update DAG status", "dag", dag.Name)
 		return ctrl.Result{}, err
 	}
@@ -149,9 +156,16 @@ func (r *DAGReconciler) markDAGFailed(ctx context.Context, dag *kontrolerv1alpha
 }
 
 func (r *DAGReconciler) markDAGSuccessful(ctx context.Context, dag *kontrolerv1alpha1.DAG) (ctrl.Result, error) {
+	// Avoid unnecessary updates
+	if dag.Status.Phase == "Successful" && dag.Status.Message == "DAG reconciled successfully" {
+		log.Log.Info("DAG already marked as successful", "dag", dag.Name)
+		return ctrl.Result{}, nil
+	}
+
+	old := dag.DeepCopy()
 	dag.Status.Phase = "Successful"
 	dag.Status.Message = "DAG reconciled successfully"
-	if err := r.Status().Update(ctx, dag); err != nil {
+	if err := r.Status().Patch(ctx, dag, client.MergeFrom(old)); err != nil {
 		log.Log.Error(err, "failed to update DAG status", "dag", dag.Name)
 		return ctrl.Result{}, err
 	}
@@ -194,7 +208,8 @@ func (r *DAGReconciler) updatingDagTaskFinalisers(ctx context.Context, taskRefs 
 				continue
 			}
 
-			if err := r.Update(ctx, &dagTask); err != nil {
+			old := dagTask.DeepCopy()
+			if err := r.Patch(ctx, &dagTask, client.MergeFrom(old)); err != nil {
 				log.Log.Error(err, "failed to add finalizer to dagTask", "taskRef", taskRef)
 			}
 		}
@@ -222,7 +237,8 @@ func (r *DAGReconciler) removingDagTaskFinalisers(ctx context.Context, taskRefs 
 				continue
 			}
 
-			if err := r.Update(ctx, &dagTask); err != nil {
+			old := dagTask.DeepCopy()
+			if err := r.Patch(ctx, &dagTask, client.MergeFrom(old)); err != nil {
 				log.Log.Error(err, "failed to remove finalizer from dagTask", "taskRef", taskRef)
 			}
 		}
@@ -239,7 +255,8 @@ func (r *DAGReconciler) handleDeletion(ctx context.Context, req ctrl.Request, da
 	// Remove the finalizer if it exists
 	if controllerutil.ContainsFinalizer(&dag, "dag.finalizer.kontroler.greedykomodo") {
 		controllerutil.RemoveFinalizer(&dag, "dag.finalizer.kontroler.greedykomodo")
-		if err := r.Update(ctx, &dag); err != nil {
+		old := dag.DeepCopy()
+		if err := r.Patch(ctx, &dag, client.MergeFrom(old)); err != nil {
 			log.Log.Error(err, "failed to remove finalizer from dag", "dag", dag.Name)
 			return ctrl.Result{}, err
 		}

--- a/controller/internal/controller/dag_controller.go
+++ b/controller/internal/controller/dag_controller.go
@@ -216,17 +216,17 @@ func (r *DAGReconciler) updatingDagTaskFinalisers(ctx context.Context, taskRefs 
 				return nil
 			}
 
+			old := dagTask.DeepCopy()
 			if !controllerutil.ContainsFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo") {
 				if updated := controllerutil.AddFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo"); !updated {
 					log.Log.Error(fmt.Errorf("AddFinalizer failed"), "failed to add finalizer to dagTask", "taskRef", tr)
 					return nil
 				}
 
-				old := dagTask.DeepCopy()
 				if err := r.Patch(gctx, &dagTask, client.MergeFrom(old)); err != nil {
 					log.Log.Error(err, "failed to add finalizer to dagTask", "taskRef", tr)
 				}
-			}
+			} 
 
 			return nil
 		})
@@ -261,16 +261,16 @@ func (r *DAGReconciler) removingDagTaskFinalisers(ctx context.Context, taskRefs 
 
 			if controllerutil.ContainsFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo") {
 
+				old := dagTask.DeepCopy()
 				if updated := controllerutil.RemoveFinalizer(&dagTask, "dagTask.finalizer.kontroler.greedykomodo"); !updated {
 					log.Log.Error(fmt.Errorf("RemoveFinalizer failed"), "failed to remove finalizer to dagTask", "taskRef", tr)
 					return nil
 				}
 
-				old := dagTask.DeepCopy()
 				if err := r.Patch(gctx, &dagTask, client.MergeFrom(old)); err != nil {
 					log.Log.Error(err, "failed to remove finalizer from dagTask", "taskRef", tr)
 				}
-			}
+			} 
 
 			return nil
 		})
@@ -292,8 +292,8 @@ func (r *DAGReconciler) handleDeletion(ctx context.Context, namespacedName types
 	if err := r.Get(ctx, namespacedName, &dag); err == nil {
 		// Remove the finalizer if it exists
 		if controllerutil.ContainsFinalizer(&dag, "dag.finalizer.kontroler.greedykomodo") {
-			controllerutil.RemoveFinalizer(&dag, "dag.finalizer.kontroler.greedykomodo")
 			old := dag.DeepCopy()
+			controllerutil.RemoveFinalizer(&dag, "dag.finalizer.kontroler.greedykomodo")
 			if err := r.Patch(ctx, &dag, client.MergeFrom(old)); err != nil {
 				log.Log.Error(err, "failed to remove finalizer from dag", "dag", dag.Name)
 				return ctrl.Result{}, err

--- a/controller/internal/controller/dag_controller.go
+++ b/controller/internal/controller/dag_controller.go
@@ -18,9 +18,9 @@ package controller
 
 import (
 	"context"
-	sterrors "errors"
 	"crypto/sha256"
 	"encoding/hex"
+	sterrors "errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controller/internal/controller/dag_controller.go
+++ b/controller/internal/controller/dag_controller.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	sterrors "errors"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -28,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kontrolerv1alpha1 "kontroler-controller/api/v1alpha1"
 	"kontroler-controller/internal/dagdsl"
@@ -64,20 +67,39 @@ func (r *DAGReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	// Keep a copy of the original object for patching later
+	orig := dag.DeepCopy()
+
 	// Check if the DAG is marked for deletion
 	if !dag.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.handleDeletion(ctx, req, dag)
 	}
 
-	// Process DSL if provided
+	// Process DSL if provided. Only do work when the DSL has changed (hash-based).
 	if dag.Spec.DSL != "" {
-		if err := r.processDSL(ctx, &dag); err != nil {
-			return r.markDAGFailed(ctx, &dag, fmt.Sprintf("failed to process DSL: %s", err.Error()))
+		hashBytes := sha256.Sum256([]byte(dag.Spec.DSL))
+		hashStr := hex.EncodeToString(hashBytes[:])
+
+		existingHash := ""
+		if dag.Annotations != nil {
+			existingHash = dag.Annotations["kontroler/dsl-hash"]
 		}
 
-		// Update the DAG with the processed DSL content
-		if err := r.Update(ctx, &dag); err != nil {
-			return r.markDAGFailed(ctx, &dag, fmt.Sprintf("failed to update DAG after DSL processing: %s", err.Error()))
+		if existingHash != hashStr {
+			if err := r.processDSL(ctx, &dag); err != nil {
+				return r.markDAGFailed(ctx, &dag, fmt.Sprintf("failed to process DSL: %s", err.Error()))
+			}
+
+			// Ensure annotations map exists and set the new hash
+			if dag.Annotations == nil {
+				dag.Annotations = map[string]string{}
+			}
+			dag.Annotations["kontroler/dsl-hash"] = hashStr
+
+			// Patch only the changes relative to the original object
+			if err := r.Patch(ctx, &dag, client.MergeFrom(orig)); err != nil {
+				return r.markDAGFailed(ctx, &dag, fmt.Sprintf("failed to patch DAG after DSL processing: %s", err.Error()))
+			}
 		}
 	}
 
@@ -150,6 +172,7 @@ func (r *DAGReconciler) deleteFromDatabase(ctx context.Context, namespacedName t
 func (r *DAGReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kontrolerv1alpha1.DAG{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }
 

--- a/controller/internal/controller/dag_controller_test.go
+++ b/controller/internal/controller/dag_controller_test.go
@@ -18,8 +18,6 @@ package controller
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,7 +32,7 @@ import (
 	"kontroler-controller/internal/db"
 
 	cron "github.com/robfig/cron/v3"
-}
+)
 
 const (
 	testImage = "alpine:latest"
@@ -265,12 +263,6 @@ task cleanup {
 			// Verify DSL is still present
 			Expect(reconciledDAG.Spec.DSL).NotTo(BeEmpty())
 
-			// Verify DSL hash annotation exists and matches the DSL
-			hashBytes := sha256.Sum256([]byte(reconciledDAG.Spec.DSL))
-			hashStr := hex.EncodeToString(hashBytes[:])
-			Expect(reconciledDAG.Annotations).NotTo(BeNil())
-			Expect(reconciledDAG.Annotations["kontroler/dsl-hash"]).To(Equal(hashStr))
-
 			// Verify the DSL was processed correctly
 			By("verifying schedule parsing")
 			Expect(reconciledDAG.Spec.Schedule).To(Equal("0 */6 * * *"))
@@ -325,79 +317,6 @@ task cleanup {
 
 			By("verifying DAG status is updated")
 			Expect(reconciledDAG.Status.Phase).NotTo(BeEmpty())
-		})
-
-		It("should skip DSL processing when hash already present", func() {
-			By("creating a DAG with DSL and precomputed hash annotation")
-			const preHashName = "prehashed-dsl-dag"
-			preHashtypeNamespacedName := types.NamespacedName{
-				Name:      preHashName,
-				Namespace: "default",
-			}
-
-			dsl := `schedule "0 */6 * * *"
-
-parameters {
-  environment {
-    default "production"
-  }
-}`
-
-			// compute the hash that controller expects
-			hashBytes := sha256.Sum256([]byte(dsl))
-			hashStr := hex.EncodeToString(hashBytes[:])
-
-			preHashedDAG := &kontrolerv1alpha1.DAG{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      preHashName,
-					Namespace: "default",
-					Annotations: map[string]string{
-						"kontroler/dsl-hash": hashStr,
-					},
-				},
-				Spec: kontrolerv1alpha1.DAGSpec{
-					DSL: dsl,
-				},
-			}
-
-			Expect(k8sClient.Create(ctx, preHashedDAG)).To(Succeed())
-
-			// Create in-memory SQLite for testing
-			parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-			config := &db.SQLiteConfig{
-				DBPath:      ":memory:",
-				JournalMode: "WAL",
-				Synchronous: "NORMAL",
-				CacheSize:   -2000,
-				TempStore:   "MEMORY",
-			}
-			dbManager, _, err := db.NewSqliteManager(context.TODO(), &parser, config)
-			Expect(err).NotTo(HaveOccurred())
-			// Initialize the database
-			err = dbManager.InitaliseDatabase(context.TODO())
-			Expect(err).NotTo(HaveOccurred())
-
-			controllerReconciler := &DAGReconciler{
-				Client:    k8sClient,
-				Scheme:    k8sClient.Scheme(),
-				DbManager: dbManager,
-			}
-
-			// Perform reconciliation. Because the annotation already contains the correct hash,
-			// the controller should skip processing the DSL and thus not populate the spec fields.
-			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: preHashtypeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
-
-			// Fetch the DAG and assert DSL-driven fields are NOT populated
-			observed := &kontrolerv1alpha1.DAG{}
-			Expect(k8sClient.Get(ctx, preHashtypeNamespacedName, observed)).To(Succeed())
-			Expect(observed.Spec.Schedule).To(Equal(""))
-
-			// Cleanup
-			Expect(k8sClient.Delete(ctx, preHashedDAG)).To(Succeed())
 		})
 
 		It("should handle invalid DSL gracefully", func() {

--- a/controller/internal/controller/dag_controller_test.go
+++ b/controller/internal/controller/dag_controller_test.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,7 +34,7 @@ import (
 	"kontroler-controller/internal/db"
 
 	cron "github.com/robfig/cron/v3"
-)
+}
 
 const (
 	testImage = "alpine:latest"
@@ -263,6 +265,12 @@ task cleanup {
 			// Verify DSL is still present
 			Expect(reconciledDAG.Spec.DSL).NotTo(BeEmpty())
 
+			// Verify DSL hash annotation exists and matches the DSL
+			hashBytes := sha256.Sum256([]byte(reconciledDAG.Spec.DSL))
+			hashStr := hex.EncodeToString(hashBytes[:])
+			Expect(reconciledDAG.Annotations).NotTo(BeNil())
+			Expect(reconciledDAG.Annotations["kontroler/dsl-hash"]).To(Equal(hashStr))
+
 			// Verify the DSL was processed correctly
 			By("verifying schedule parsing")
 			Expect(reconciledDAG.Spec.Schedule).To(Equal("0 */6 * * *"))
@@ -317,6 +325,79 @@ task cleanup {
 
 			By("verifying DAG status is updated")
 			Expect(reconciledDAG.Status.Phase).NotTo(BeEmpty())
+		})
+
+		It("should skip DSL processing when hash already present", func() {
+			By("creating a DAG with DSL and precomputed hash annotation")
+			const preHashName = "prehashed-dsl-dag"
+			preHashtypeNamespacedName := types.NamespacedName{
+				Name:      preHashName,
+				Namespace: "default",
+			}
+
+			dsl := `schedule "0 */6 * * *"
+
+parameters {
+  environment {
+    default "production"
+  }
+}`
+
+			// compute the hash that controller expects
+			hashBytes := sha256.Sum256([]byte(dsl))
+			hashStr := hex.EncodeToString(hashBytes[:])
+
+			preHashedDAG := &kontrolerv1alpha1.DAG{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      preHashName,
+					Namespace: "default",
+					Annotations: map[string]string{
+						"kontroler/dsl-hash": hashStr,
+					},
+				},
+				Spec: kontrolerv1alpha1.DAGSpec{
+					DSL: dsl,
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, preHashedDAG)).To(Succeed())
+
+			// Create in-memory SQLite for testing
+			parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+			config := &db.SQLiteConfig{
+				DBPath:      ":memory:",
+				JournalMode: "WAL",
+				Synchronous: "NORMAL",
+				CacheSize:   -2000,
+				TempStore:   "MEMORY",
+			}
+			dbManager, _, err := db.NewSqliteManager(context.TODO(), &parser, config)
+			Expect(err).NotTo(HaveOccurred())
+			// Initialize the database
+			err = dbManager.InitaliseDatabase(context.TODO())
+			Expect(err).NotTo(HaveOccurred())
+
+			controllerReconciler := &DAGReconciler{
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				DbManager: dbManager,
+			}
+
+			// Perform reconciliation. Because the annotation already contains the correct hash,
+			// the controller should skip processing the DSL and thus not populate the spec fields.
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: preHashtypeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			// Fetch the DAG and assert DSL-driven fields are NOT populated
+			observed := &kontrolerv1alpha1.DAG{}
+			Expect(k8sClient.Get(ctx, preHashtypeNamespacedName, observed)).To(Succeed())
+			Expect(observed.Spec.Schedule).To(Equal(""))
+
+			// Cleanup
+			Expect(k8sClient.Delete(ctx, preHashedDAG)).To(Succeed())
 		})
 
 		It("should handle invalid DSL gracefully", func() {

--- a/controller/internal/controller/dag_dslhash_test.go
+++ b/controller/internal/controller/dag_dslhash_test.go
@@ -1,0 +1,102 @@
+package controller
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	kontrolerv1alpha1 "kontroler-controller/api/v1alpha1"
+	"kontroler-controller/internal/db"
+
+	cron "github.com/robfig/cron/v3"
+)
+
+var _ = Describe("DAG DSL hash behavior", func() {
+	ctx := context.Background()
+
+	It("writes a kontoler/dsl-hash annotation when processing DSL", func() {
+		name := "dsl-hash-write"
+		nn := types.NamespacedName{Name: name, Namespace: "default"}
+
+		dsl := `schedule "0 */6 * * *"
+
+parameters {
+  environment {
+    default "production"
+  }
+}`
+
+		dag := &kontrolerv1alpha1.DAG{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec:       kontrolerv1alpha1.DAGSpec{DSL: dsl},
+		}
+
+		Expect(k8sClient.Create(ctx, dag)).To(Succeed())
+
+		// Setup DB
+		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+		config := &db.SQLiteConfig{DBPath: ":memory:", JournalMode: "WAL", Synchronous: "NORMAL", CacheSize: -2000, TempStore: "MEMORY"}
+		dbManager, _, err := db.NewSqliteManager(context.TODO(), &parser, config)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dbManager.InitaliseDatabase(context.TODO())).To(Succeed())
+
+		reconciler := &DAGReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), DbManager: dbManager}
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		reconciled := &kontrolerv1alpha1.DAG{}
+		Expect(k8sClient.Get(ctx, nn, reconciled)).To(Succeed())
+
+		hash := sha256.Sum256([]byte(reconciled.Spec.DSL))
+		hs := hex.EncodeToString(hash[:])
+		Expect(reconciled.Annotations).NotTo(BeNil())
+		Expect(reconciled.Annotations["kontroler/dsl-hash"]).To(Equal(hs))
+
+		Expect(k8sClient.Delete(ctx, reconciled)).To(Succeed())
+	})
+
+	It("skips processing when kontoler/dsl-hash already present", func() {
+		name := "dsl-hash-skip"
+		nn := types.NamespacedName{Name: name, Namespace: "default"}
+
+		dsl := `schedule "0 */6 * * *"
+
+parameters {
+  environment {
+    default "production"
+  }
+}`
+		hash := sha256.Sum256([]byte(dsl))
+		hs := hex.EncodeToString(hash[:])
+
+		dag := &kontrolerv1alpha1.DAG{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Annotations: map[string]string{"kontroler/dsl-hash": hs}},
+			Spec:       kontrolerv1alpha1.DAGSpec{DSL: dsl},
+		}
+
+		Expect(k8sClient.Create(ctx, dag)).To(Succeed())
+
+		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+		config := &db.SQLiteConfig{DBPath: ":memory:", JournalMode: "WAL", Synchronous: "NORMAL", CacheSize: -2000, TempStore: "MEMORY"}
+		dbManager, _, err := db.NewSqliteManager(context.TODO(), &parser, config)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dbManager.InitaliseDatabase(context.TODO())).To(Succeed())
+
+		reconciler := &DAGReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), DbManager: dbManager}
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		observed := &kontrolerv1alpha1.DAG{}
+		Expect(k8sClient.Get(ctx, nn, observed)).To(Succeed())
+		// schedule should remain empty as processing was skipped
+		Expect(observed.Spec.Schedule).To(Equal(""))
+
+		Expect(k8sClient.Delete(ctx, observed)).To(Succeed())
+	})
+})

--- a/controller/internal/controller/dag_dslhash_test.go
+++ b/controller/internal/controller/dag_dslhash_test.go
@@ -20,7 +20,7 @@ import (
 var _ = Describe("DAG DSL hash behavior", func() {
 	ctx := context.Background()
 
-	It("writes a kontoler/dsl-hash annotation when processing DSL", func() {
+	It("writes a kontroler/dsl-hash annotation when processing DSL", func() {
 		name := "dsl-hash-write"
 		nn := types.NamespacedName{Name: name, Namespace: "default"}
 
@@ -99,7 +99,7 @@ task cleanup {
 		Expect(k8sClient.Delete(ctx, reconciled)).To(Succeed())
 	})
 
-	It("skips processing when kontoler/dsl-hash already present", func() {
+	It("skips processing when kontroler/dsl-hash already present", func() {
 		name := "dsl-hash-skip"
 		nn := types.NamespacedName{Name: name, Namespace: "default"}
 

--- a/controller/internal/controller/dag_dslhash_test.go
+++ b/controller/internal/controller/dag_dslhash_test.go
@@ -30,10 +30,16 @@ parameters {
   environment {
     default "production"
   }
+  replicas {
+    default "3"
+  }
 }
 
 graph {
-  setup
+  setup -> deploy
+  setup -> test
+  deploy -> cleanup
+  test -> cleanup
 }
 
 task setup {
@@ -41,6 +47,27 @@ task setup {
   command ["sh", "-c"]
   args ["echo 'Setting up environment'"]
   parameters ["environment"]
+}
+
+task deploy {
+  image "alpine:latest"
+  script """
+  echo "Deploying application to $ENVIRONMENT"
+  echo "Using $REPLICAS replicas"
+  """
+  parameters ["environment", "replicas"]
+}
+
+task test {
+  image "alpine:latest"
+  script "echo 'Running tests'"
+  retry [1, 2, 125]
+}
+
+task cleanup {
+  image "alpine:latest"
+  command ["sh", "-c"]
+  args ["echo 'Cleaning up resources'"]
 }`
 
 		dag := &kontrolerv1alpha1.DAG{
@@ -82,10 +109,16 @@ parameters {
   environment {
     default "production"
   }
+  replicas {
+    default "3"
+  }
 }
 
 graph {
-  setup
+  setup -> deploy
+  setup -> test
+  deploy -> cleanup
+  test -> cleanup
 }
 
 task setup {
@@ -93,6 +126,27 @@ task setup {
   command ["sh", "-c"]
   args ["echo 'Setting up environment'"]
   parameters ["environment"]
+}
+
+task deploy {
+  image "alpine:latest"
+  script """
+  echo "Deploying application to $ENVIRONMENT"
+  echo "Using $REPLICAS replicas"
+  """
+  parameters ["environment", "replicas"]
+}
+
+task test {
+  image "alpine:latest"
+  script "echo 'Running tests'"
+  retry [1, 2, 125]
+}
+
+task cleanup {
+  image "alpine:latest"
+  command ["sh", "-c"]
+  args ["echo 'Cleaning up resources'"]
 }`
 		hash := sha256.Sum256([]byte(dsl))
 		hs := hex.EncodeToString(hash[:])

--- a/controller/internal/controller/dag_dslhash_test.go
+++ b/controller/internal/controller/dag_dslhash_test.go
@@ -30,6 +30,17 @@ parameters {
   environment {
     default "production"
   }
+}
+
+graph {
+  setup
+}
+
+task setup {
+  image "alpine:latest"
+  command ["sh", "-c"]
+  args ["echo 'Setting up environment'"]
+  parameters ["environment"]
 }`
 
 		dag := &kontrolerv1alpha1.DAG{
@@ -71,6 +82,17 @@ parameters {
   environment {
     default "production"
   }
+}
+
+graph {
+  setup
+}
+
+task setup {
+  image "alpine:latest"
+  command ["sh", "-c"]
+  args ["echo 'Setting up environment'"]
+  parameters ["environment"]
 }`
 		hash := sha256.Sum256([]byte(dsl))
 		hs := hex.EncodeToString(hash[:])

--- a/controller/internal/controller/dagrun_controller.go
+++ b/controller/internal/controller/dagrun_controller.go
@@ -80,13 +80,16 @@ func (r *DagRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Add finalizer if it doesn't exist
 	if !containsString(dagRun.Finalizers, dagRunFinalizer) {
-		dagRun.Finalizers = append(dagRun.Finalizers, dagRunFinalizer)
 		old := dagRun.DeepCopy()
+		dagRun.Finalizers = append(dagRun.Finalizers, dagRunFinalizer)
 		if err := r.Patch(ctx, &dagRun, client.MergeFrom(old)); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, nil
-	}
+		// Requeue so the reconcile loop continues and sees the object with the
+		// finalizer in place. Because GenerationChangedPredicate filters out
+		// metadata-only updates, requeueing ensures we process the object.
+		return ctrl.Result{Requeue: true}, nil
+	} 
 
 	// check if dag exists
 	ok, dagId, err := r.DbManager.DagExists(ctx, dagRun.Spec.DagName)
@@ -287,8 +290,8 @@ func (r *DagRunReconciler) handleDeletion(ctx context.Context, dagRun *kontroler
 	}
 
 	// Remove the finalizer
-	dagRun.Finalizers = removeString(dagRun.Finalizers, dagRunFinalizer)
 	old := dagRun.DeepCopy()
+	dagRun.Finalizers = removeString(dagRun.Finalizers, dagRunFinalizer)
 	if err := r.Patch(ctx, dagRun, client.MergeFrom(old)); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controller/internal/controller/dagrun_controller.go
+++ b/controller/internal/controller/dagrun_controller.go
@@ -80,7 +80,8 @@ func (r *DagRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Add finalizer if it doesn't exist
 	if !containsString(dagRun.Finalizers, dagRunFinalizer) {
 		dagRun.Finalizers = append(dagRun.Finalizers, dagRunFinalizer)
-		if err := r.Update(ctx, &dagRun); err != nil {
+		old := dagRun.DeepCopy()
+		if err := r.Patch(ctx, &dagRun, client.MergeFrom(old)); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -199,10 +200,13 @@ func (r *DagRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	}
 
+	old := dagRun.DeepCopy()
 	dagRun.Status.DagRunId = runId
-	if err := r.Status().Update(ctx, &dagRun); err != nil {
-		log.Log.Error(err, "failed to update DagRun status with runID", "dag_id", dagRun.Spec.DagName)
-		return ctrl.Result{}, err
+	if old.Status.DagRunId != dagRun.Status.DagRunId {
+		if err := r.Status().Patch(ctx, &dagRun, client.MergeFrom(old)); err != nil {
+			log.Log.Error(err, "failed to update DagRun status with runID", "dag_id", dagRun.Spec.DagName)
+			return ctrl.Result{}, err
+		}
 	}
 
 	return ctrl.Result{}, nil
@@ -273,7 +277,8 @@ func (r *DagRunReconciler) handleDeletion(ctx context.Context, dagRun *kontroler
 
 	// Remove the finalizer
 	dagRun.Finalizers = removeString(dagRun.Finalizers, dagRunFinalizer)
-	if err := r.Update(ctx, dagRun); err != nil {
+	old := dagRun.DeepCopy()
+	if err := r.Patch(ctx, dagRun, client.MergeFrom(old)); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/controller/internal/controller/dagrun_controller.go
+++ b/controller/internal/controller/dagrun_controller.go
@@ -25,6 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -211,6 +212,7 @@ func (r *DagRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 func (r *DagRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kontrolerv1alpha1.DagRun{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }
 

--- a/controller/internal/controller/dagrun_controller.go
+++ b/controller/internal/controller/dagrun_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -262,12 +263,22 @@ func (r *DagRunReconciler) handleDeletion(ctx context.Context, dagRun *kontroler
 		return ctrl.Result{}, err
 	}
 
+	// delete pods in parallel with bounded concurrency
+	const podConcurrency = 8
+	sem := make(chan struct{}, podConcurrency)
+	g, gctx := errgroup.WithContext(ctx)
 	for _, pod := range pods {
-		if err := deletePodByNameAndNamespace(ctx, r.Client, pod.Name, pod.Namespace); err != nil {
-			log.Log.Error(err, "failed to delete pod", "podName", pod.Name, "podNamespace", pod.Namespace)
-			continue
-		}
+		pod := pod
+		sem <- struct{}{}
+		g.Go(func() error {
+			defer func() { <-sem }()
+			if err := deletePodByNameAndNamespace(gctx, r.Client, pod.Name, pod.Namespace); err != nil {
+				log.Log.Error(err, "failed to delete pod", "podName", pod.Name, "podNamespace", pod.Namespace)
+			}
+			return nil
+		})
 	}
+	_ = g.Wait()
 
 	// Delete the DAG run from database
 	if err := r.DbManager.DeleteDagRun(ctx, dagRun.Status.DagRunId); err != nil {

--- a/controller/internal/controller/dagrun_controller.go
+++ b/controller/internal/controller/dagrun_controller.go
@@ -91,7 +91,7 @@ func (r *DagRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// check if dag exists
 	ok, dagId, err := r.DbManager.DagExists(ctx, dagRun.Spec.DagName)
 	if err != nil {
-		log.Log.Error(err, "failed to check if dag exits", "dag_id", dagRun.Spec.DagName)
+		log.Log.Error(err, "failed to check if dag exists", "dag_id", dagRun.Spec.DagName)
 		return ctrl.Result{}, err
 	}
 
@@ -176,7 +176,7 @@ func (r *DagRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	for _, task := range tasks {
 		taskRunId, err := r.DbManager.MarkTaskAsStarted(ctx, runId, task.Id)
 		if err != nil {
-			log.Log.Error(err, "failed to mask task as stated", "dag_id", dagRun.Spec.DagName, "task_id", task.Id)
+			log.Log.Error(err, "failed to mark task as started", "dag_id", dagRun.Spec.DagName, "task_id", task.Id)
 			continue
 		}
 
@@ -264,7 +264,7 @@ func (r *DagRunReconciler) handleDeletion(ctx context.Context, dagRun *kontroler
 	}
 
 	// delete pods in parallel with bounded concurrency
-	const podConcurrency = 8
+	const podConcurrency = defaultConcurrency
 	sem := make(chan struct{}, podConcurrency)
 	g, gctx := errgroup.WithContext(ctx)
 	for _, pod := range pods {
@@ -323,8 +323,9 @@ func deletePVCByNameAndNamespace(ctx context.Context, c client.Client, name stri
 	}
 
 	// Remove all finalizers from the PVC
+	old := pvc.DeepCopy()
 	pvc.Finalizers = []string{}
-	if err := c.Update(ctx, pvc); err != nil {
+	if err := c.Patch(ctx, pvc, client.MergeFrom(old)); err != nil {
 		return err
 	}
 
@@ -376,7 +377,8 @@ func deletePodByNameAndNamespace(ctx context.Context, c client.Client, name stri
 		}
 	}
 	pod.ObjectMeta.Finalizers = finalisers
-	if err := c.Update(ctx, pod); err != nil {
+	old := pod.DeepCopy()
+	if err := c.Patch(ctx, pod, client.MergeFrom(old)); err != nil {
 		return err
 	}
 

--- a/controller/internal/controller/dagtask_controller.go
+++ b/controller/internal/controller/dagtask_controller.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kontrolerv1alpha1 "kontroler-controller/api/v1alpha1"
 	"kontroler-controller/internal/db"
@@ -94,6 +95,7 @@ func (r *DagTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func (r *DagTaskReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kontrolerv1alpha1.DagTask{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }
 


### PR DESCRIPTION
This pull request introduces several improvements to the controller's configuration, reconciliation logic, and testing, with a focus on making local and CI testing easier and improving efficiency and correctness in the controller's batch operations. The changes include new documentation on defaults, better handling of configuration and environment variables, hash-based reconciliation for DAG DSLs, concurrency improvements, and updates to container images and deployment manifests.

**Key changes:**

### Controller defaults, configuration, and documentation

- Added a new section in `README.md` explaining local/CI-friendly defaults, environment variables, and quickstart instructions for local testing. This includes details on the default config, database selection, concurrency tuning, webhook/cert-manager setup, and image handling for Kind clusters.
- The controller now uses a built-in default configuration when no `--configpath` is provided, making local/test runs easier. This includes sensible defaults for workers, log storage, and leader election. The deployment manifest is updated to use these defaults. [[1]](diffhunk://#diff-762154fda880a404e53bbf7fdb948365712670a15f9a0004bd5384ec275f5a0aL153-R184) [[2]](diffhunk://#diff-275a5a40bff5ab3253bfab75b09422089086dbdda501c7994719202bfdabf6ccL74-R80)

### Reconciliation and batch operation improvements

- The DAG reconciler now computes and stores a hash of the DSL in an annotation (`kontroler/dsl-hash`) and only reprocesses the DSL if it has changed, reducing unnecessary work. Associated logic is tested in a new unit test. [[1]](diffhunk://#diff-2580daac4a14a38a89387c52166057b1fe744855a2a6cf4c76aed93601775e47L62-R106) [[2]](diffhunk://#diff-afbac103f1c6c6d4f057d9d582c416671d2656241c0ba41d94c08e103249f0deR1-R178)
- Batch operations for adding/removing DAG task finalizers are now performed with bounded concurrency (default 8), improving efficiency and preventing resource exhaustion. [[1]](diffhunk://#diff-2580daac4a14a38a89387c52166057b1fe744855a2a6cf4c76aed93601775e47R48-R50) [[2]](diffhunk://#diff-2580daac4a14a38a89387c52166057b1fe744855a2a6cf4c76aed93601775e47R193-R307)
- Status and object updates now use patching instead of full updates, and unnecessary updates are avoided by checking if the status/message is already set. [[1]](diffhunk://#diff-2580daac4a14a38a89387c52166057b1fe744855a2a6cf4c76aed93601775e47R145-R154) [[2]](diffhunk://#diff-2580daac4a14a38a89387c52166057b1fe744855a2a6cf4c76aed93601775e47R163-R172) [[3]](diffhunk://#diff-0630c7ff75958643100fb5ab7314b0a07c0805c52b3bf374f95c340c790e5a62L82-R85)

### Deployment and image updates

- Updated the default deployment image name and tag to `example.com/operator:v0.0.1` and set the imagePullPolicy to `IfNotPresent` for better local development and testing. [[1]](diffhunk://#diff-a93174bb2c7764beda936baaefab5788f82fee098ac6ef0cdd04b0e9f5bc2083L7-R8) [[2]](diffhunk://#diff-275a5a40bff5ab3253bfab75b09422089086dbdda501c7994719202bfdabf6ccL74-R80)
- Updated the kube-rbac-proxy image to a newer version and switched to the `quay.io` registry.

### Controller-runtime enhancements

- The DAG and DagRun reconcilers now use the `GenerationChangedPredicate` to filter events, ensuring reconciliation only occurs on spec changes. [[1]](diffhunk://#diff-2580daac4a14a38a89387c52166057b1fe744855a2a6cf4c76aed93601775e47R193-R307) [[2]](diffhunk://#diff-0630c7ff75958643100fb5ab7314b0a07c0805c52b3bf374f95c340c790e5a62R23-R29)

### Testing

- Added a new test file to verify the DSL hash annotation logic and ensure the controller skips unnecessary processing when the hash matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added default in-memory configuration support when no config path is provided, enabling simpler local testing without requiring separate configuration files.
  * Implemented hash-based DSL processing to optimise reconciliation by caching results and only reprocessing when DSL changes.

* **Documentation**
  * Added "Defaults and local testing notes" section to controller documentation, including guidance on local e2e testing setup, environment variables, webhook configuration, and local Kind-based development.

* **Chores**
  * Updated kube-rbac-proxy image to v0.16.0.
  * Changed image pull policy to `IfNotPresent` for more efficient cluster operations.
  * Updated controller image reference and added SQLite environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->