### PR TITLE
docs: add Server and UI Kubernetes examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,10 @@ export IMAGE_TAG_BASE=YOUR_NAMESPACE/kontroler-server
 make docker-build docker-push
 ```
 
-Currently there is no Helm chart to handle this so for now you will need to create your own, this is coming soon!
+The unified Helm chart in `helm/kontroler` can deploy the server. If you want
+plain Kubernetes YAML instead, start from
+`examples/k8s/server-deployment.yaml` and replace the image tag, database
+settings, and `JWT_KEY` secret before applying it.
 
 To help we can provide the role need to run the server at the cluster level:
 
@@ -565,7 +568,9 @@ export IMAGE_TAG_BASE=YOUR_NAMESPACE/kontroler-ui
 make docker-build docker-push
 ```
 
-Currently there is no Helm chart to handle this so for now you will need to create your own, this is coming soon!
+The unified Helm chart in `helm/kontroler` can deploy the UI. If you want plain
+Kubernetes YAML instead, start from `examples/k8s/ui-deployment.yaml` and update
+`API_URL` / `WS_URL` if your server is exposed outside the example namespace.
 
 # Contributing
 

--- a/examples/k8s/server-deployment.yaml
+++ b/examples/k8s/server-deployment.yaml
@@ -36,7 +36,8 @@ data:
   DB_TYPE: postgresql
   DB_NAME: kontroler
   DB_USER: postgres
-  DB_ENDPOINT: postgres-postgresql.default.svc.cluster.local:5432
+  # Replace with your PostgreSQL service endpoint.
+  DB_ENDPOINT: your-postgres-service.your-namespace.svc.cluster.local:5432
   UI_ADDRESS: http://kontroler-ui.kontroler.svc.cluster.local:3000
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -87,10 +88,20 @@ spec:
         app.kubernetes.io/part-of: kontroler
     spec:
       serviceAccountName: kontroler-server
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: kontroler-server
           image: greedykomodo/kontroler-server:0.0.1
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           args:
             - --configpath=/etc/kontroler/config/config.yaml
           env:
@@ -138,6 +149,8 @@ spec:
             - name: config
               mountPath: /etc/kontroler/config
               readOnly: true
+            - name: logs
+              mountPath: /logs
       volumes:
         - name: config
           configMap:
@@ -145,6 +158,8 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+        - name: logs
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/examples/k8s/server-deployment.yaml
+++ b/examples/k8s/server-deployment.yaml
@@ -1,0 +1,167 @@
+# Example non-Helm Kontroler Server deployment.
+# Replace placeholder image tags, database values, and secrets before applying.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kontroler
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kontroler-server
+  namespace: kontroler
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kontroler-server-secrets
+  namespace: kontroler
+type: Opaque
+stringData:
+  DB_PASSWORD: replace-me
+  JWT_KEY: replace-with-a-long-random-value
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kontroler-server-config
+  namespace: kontroler
+data:
+  config.yaml: |
+    kubeConfigPath: ""
+    logStorage:
+      storeType: filesystem
+      fileSystem:
+        baseDir: /logs
+  DB_TYPE: postgresql
+  DB_NAME: kontroler
+  DB_USER: postgres
+  DB_ENDPOINT: postgres-postgresql.default.svc.cluster.local:5432
+  UI_ADDRESS: http://kontroler-ui.kontroler.svc.cluster.local:3000
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kontroler-server-dag-access
+rules:
+  - apiGroups: ["kontroler.greedykomodo"]
+    resources: ["dags"]
+    verbs: ["create", "get", "list", "delete", "update"]
+  - apiGroups: ["kontroler.greedykomodo"]
+    resources: ["dagruns"]
+    verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kontroler-server-dag-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kontroler-server-dag-access
+subjects:
+  - kind: ServiceAccount
+    name: kontroler-server
+    namespace: kontroler
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kontroler-server
+  namespace: kontroler
+  labels:
+    app.kubernetes.io/name: kontroler-server
+    app.kubernetes.io/part-of: kontroler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kontroler-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kontroler-server
+        app.kubernetes.io/part-of: kontroler
+    spec:
+      serviceAccountName: kontroler-server
+      containers:
+        - name: kontroler-server
+          image: greedykomodo/kontroler-server:0.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --configpath=/etc/kontroler/config/config.yaml
+          env:
+            - name: DB_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: kontroler-server-config
+                  key: DB_TYPE
+            - name: DB_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: kontroler-server-config
+                  key: DB_NAME
+            - name: DB_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: kontroler-server-config
+                  key: DB_USER
+            - name: DB_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: kontroler-server-config
+                  key: DB_ENDPOINT
+            - name: UI_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  name: kontroler-server-config
+                  key: UI_ADDRESS
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kontroler-server-secrets
+                  key: DB_PASSWORD
+            - name: JWT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: kontroler-server-secrets
+                  key: JWT_KEY
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: metrics
+              containerPort: 2112
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kontroler/config
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: kontroler-server-config
+            items:
+              - key: config.yaml
+                path: config.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kontroler-server
+  namespace: kontroler
+  labels:
+    app.kubernetes.io/name: kontroler-server
+    app.kubernetes.io/part-of: kontroler
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: kontroler-server
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+    - name: metrics
+      port: 2112
+      targetPort: metrics

--- a/examples/k8s/ui-deployment.yaml
+++ b/examples/k8s/ui-deployment.yaml
@@ -1,0 +1,79 @@
+# Example non-Helm Kontroler UI deployment.
+# Apply server-deployment.yaml first, or update API_URL/WS_URL for your server route.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kontroler
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kontroler-ui
+  namespace: kontroler
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kontroler-ui-env
+  namespace: kontroler
+data:
+  # These values are read by the browser, not by another pod. The defaults work
+  # with `kubectl port-forward svc/kontroler-server 8080:8080`.
+  API_URL: http://localhost:8080
+  WS_URL: ws://localhost:8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kontroler-ui
+  namespace: kontroler
+  labels:
+    app.kubernetes.io/name: kontroler-ui
+    app.kubernetes.io/part-of: kontroler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kontroler-ui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kontroler-ui
+        app.kubernetes.io/part-of: kontroler
+    spec:
+      serviceAccountName: kontroler-ui
+      containers:
+        - name: kontroler-ui
+          image: greedykomodo/kontroler-ui:0.0.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: kontroler-ui-env
+                  key: API_URL
+            - name: WS_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: kontroler-ui-env
+                  key: WS_URL
+          ports:
+            - name: http
+              containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kontroler-ui
+  namespace: kontroler
+  labels:
+    app.kubernetes.io/name: kontroler-ui
+    app.kubernetes.io/part-of: kontroler
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: kontroler-ui
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http

--- a/examples/k8s/ui-deployment.yaml
+++ b/examples/k8s/ui-deployment.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: kontroler
 data:
   # These values are read by the browser, not by another pod. The defaults work
-  # with `kubectl port-forward svc/kontroler-server 8080:8080`.
+  # with `kubectl port-forward -n kontroler svc/kontroler-server 8080:8080`.
   API_URL: http://localhost:8080
   WS_URL: ws://localhost:8080
 ---
@@ -42,10 +42,20 @@ spec:
         app.kubernetes.io/part-of: kontroler
     spec:
       serviceAccountName: kontroler-ui
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: kontroler-ui
           image: greedykomodo/kontroler-ui:0.0.1
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: API_URL
               valueFrom:
@@ -60,6 +70,12 @@ spec:
           ports:
             - name: http
               containerPort: 3000
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

Adds plain Kubernetes examples for deploying the Kontroler Server and UI without Helm.

- `examples/k8s/server-deployment.yaml`: namespace, service account, placeholder Secret, ConfigMap, RBAC, Deployment, and Service
- `examples/k8s/ui-deployment.yaml`: namespace, service account, browser-facing API/WS config, Deployment, and Service
- README now points users to the existing unified Helm chart and these non-Helm examples

## Notes

The examples intentionally keep secret values as placeholders and use the published `greedykomodo/kontroler-server:0.0.1` / `greedykomodo/kontroler-ui:0.0.1` images already used by the Helm values.

## Verification

- Parsed both YAML files with Python `yaml.safe_load_all`
- `git diff --check`

Kubectl client-side dry-run was not useful on this machine because the local kubectl context has no reachable API server.

Closes #177.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README deployment guidance to reference the unified Helm chart for Server and UI components, alongside plain Kubernetes YAML alternatives.
  * Added example Kubernetes manifests for both Server and UI, enabling deployment without Helm by customising image tags and connection settings as required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GreedyKomodoDragon/Kontroler/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->