### PR TITLE
New Worker Pattern

### DIFF
--- a/controller/Dockerfile.worker
+++ b/controller/Dockerfile.worker
@@ -1,0 +1,14 @@
+# Build a minimal worker binary and package with distroless
+FROM docker.io/library/golang:1.25 AS builder
+WORKDIR /workspace
+COPY go.mod go.sum ./
+RUN go mod download
+COPY ./cmd/worker ./cmd/worker
+COPY ./internal ./internal
+COPY ./api ./api
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /workspace/worker ./cmd/worker/main.go
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /workspace/worker /worker
+USER nonroot
+ENTRYPOINT ["/worker"]

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -188,7 +188,23 @@ docker-build-server: ## Build docker image for the server.
 docker-push-server: ## Push docker image for the server.
 	$(CONTAINER_TOOL) push ${SERVER_IMG}
 
+# Worker image helpers
+WORKER_IMG ?= greedykomodo/kontroler-worker:latest
+DOCKERFILE_WORKER ?= Dockerfile.worker
+.PHONY: docker-build-worker
+docker-build-worker: ## Build docker image for the worker binary.
+	$(CONTAINER_TOOL) build -t ${WORKER_IMG} -f $(DOCKERFILE_WORKER) .
+
+.PHONY: kind-load-worker
+kind-load-worker: docker-build-worker ## Build & load worker image to kind
+	kind load docker-image $(WORKER_IMG) --name $(KIND_CLUSTER_NAME)
+
 ##@ Kind Cluster Management
+
+.PHONY: kind-integration-workerpool
+kind-integration-workerpool: ## Run integration test for WorkerPool controller inside kind (requires kind, kubectl, helm)
+	./test/integration/workerpool_integration.sh
+
 
 KIND_CLUSTER_NAME ?= kind
 

--- a/controller/api/v1alpha1/workerpool_types.go
+++ b/controller/api/v1alpha1/workerpool_types.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+)
+
+// WorkerPoolSpec defines the desired state of WorkerPool
+type WorkerPoolSpec struct {
+	// Replicas is the desired number of worker pods
+	// +optional
+	Replicas *int32 `json:"replicas,omitempty"`
+
+	// Image is the container image to run for the worker
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// Concurrency settings
+	// +optional
+	Concurrency *struct {
+		// MaxConcurrentClaims is the max concurrent claim-processing goroutines per pod
+		// +optional
+		MaxConcurrentClaims *int32 `json:"maxConcurrentClaims,omitempty"`
+		// ClaimBatchSize controls how many tasks to claim per DB call
+		// +optional
+		ClaimBatchSize *int32 `json:"claimBatchSize,omitempty"`
+	} `json:"concurrency,omitempty"`
+
+	// Lease settings
+	// +optional
+	Lease *struct {
+		// TTLSeconds is the lease TTL in seconds
+		// +optional
+		TTLSeconds *int32 `json:"ttlSeconds,omitempty"`
+	} `json:"lease,omitempty"`
+
+	// PodTemplate allows customizing pod-level values like nodeSelector, tolerations, resources and serviceAccountName
+	// Re-uses the local CRD-safe PodTemplateSpec defined in DAG types
+	// +optional
+	PodTemplate *PodTemplateSpec `json:"podTemplate,omitempty"`
+
+	// DB secret name to mount into worker pods as env (operator will mount)
+	// +optional
+	DBSecretRef string `json:"dbSecretRef,omitempty"`
+
+	// Metrics related options
+	// +optional
+	Metrics *struct {
+		Enabled    bool   `json:"enabled,omitempty"`
+		ScrapePort *int32 `json:"scrapePort,omitempty"`
+	} `json:"metrics,omitempty"`
+
+	// Graceful shutdown period in seconds
+	// +optional
+	GracefulShutdownSeconds *int32 `json:"gracefulShutdownSeconds,omitempty"`
+}
+
+// WorkerPoolStatus defines the observed state of WorkerPool
+type WorkerPoolStatus struct {
+	// Replicas is the number of desired replicas. Mirrors Deployment.spec.replicas
+	// +optional
+	Replicas int32 `json:"replicas,omitempty"`
+
+	// ReadyReplicas is the number of ready replicas. Mirrors Deployment.status.readyReplicas
+	// +optional
+	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
+
+	// LastReconcileTime is the last time the controller reconciled the resource
+	// +optional
+	LastReconcileTime *metav1.Time `json:"lastReconcileTime,omitempty"`
+}
+
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+
+// WorkerPool is the Schema for the workerpools API
+type WorkerPool struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   WorkerPoolSpec   `json:"spec,omitempty"`
+	Status WorkerPoolStatus `json:"status,omitempty"`
+}
+
+//+kubebuilder:object:root=true
+
+// WorkerPoolList contains a list of WorkerPool
+type WorkerPoolList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []WorkerPool `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&WorkerPool{}, &WorkerPoolList{})
+}
+
+// DeepCopyObject implements runtime.Object for WorkerPool
+func (in *WorkerPool) DeepCopyObject() runtime.Object {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+// DeepCopyObject implements runtime.Object for WorkerPoolList
+func (in *WorkerPoolList) DeepCopyObject() runtime.Object {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}

--- a/controller/cmd/controller/main.go
+++ b/controller/cmd/controller/main.go
@@ -539,6 +539,7 @@ func main() {
 	// Close all watcher channels
 	for i := 0; i < len(configController.Workers.Workers); i++ {
 		close(closeChannels[i])
+		close(closeEventChannels[i])
 	}
 
 	// Wait for all goroutines to finish

--- a/controller/cmd/worker/main.go
+++ b/controller/cmd/worker/main.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"kontroler-controller/internal/db"
+	"kontroler-controller/internal/object"
+	"kontroler-controller/internal/queue"
+	"kontroler-controller/internal/webhook"
+	"kontroler-controller/internal/workers"
+
+	"github.com/google/uuid"
+	pgxpool "github.com/jackc/pgx/v5/pgxpool"
+	cron "github.com/robfig/cron/v3"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func main() {
+	var configPath string
+	var pollDurationStr string
+	flag.StringVar(&configPath, "configpath", "", "Path to worker config file (optional)")
+	flag.StringVar(&pollDurationStr, "poll", "100ms", "task claim poll duration")
+	flag.Parse()
+
+	logger := ctrlzap.New(ctrlzap.UseDevMode(true))
+	logf.SetLogger(logger)
+
+	// Prepare context and signal handling
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	// Determine kube config
+	var cfg *rest.Config
+	var err error
+	if cfgPath := os.Getenv("KUBECONFIG"); cfgPath != "" {
+		cfg, err = clientcmd.BuildConfigFromFlags("", cfgPath)
+	} else {
+		cfg, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		logf.Log.Error(err, "failed to build kubeconfig")
+		os.Exit(1)
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		logf.Log.Error(err, "failed to create clientset")
+		os.Exit(1)
+	}
+
+	// Configure DB manager
+	var dbManager db.DBDAGManager
+	specParser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	switch os.Getenv("DB_TYPE") {
+	case "postgresql":
+		pgConfig, err := db.ConfigurePostgres()
+		if err != nil {
+			logf.Log.Error(err, "failed to configure postgres")
+			os.Exit(1)
+		}
+		pool, err := pgxpool.NewWithConfig(context.Background(), pgConfig)
+		if err != nil {
+			logf.Log.Error(err, "failed to create postgres pool")
+			os.Exit(1)
+		}
+		defer pool.Close()
+		dbManager, err = db.NewPostgresDAGManagerWithMetrics(context.Background(), pool, &specParser)
+		if err != nil {
+			logf.Log.Error(err, "failed to create postgres dag manager")
+			os.Exit(1)
+		}
+	default:
+		// default to sqlite
+		cfg, err := db.ConfigureSqlite()
+		if err != nil {
+			logf.Log.Error(err, "failed to configure sqlite")
+			os.Exit(1)
+		}
+		dbm, dbConn, err := db.NewSqliteManagerWithMetrics(context.Background(), &specParser, cfg)
+		if err != nil {
+			logf.Log.Error(err, "failed to create sqlite manager")
+			os.Exit(1)
+		}
+		defer dbConn.Close()
+		dbManager = dbm
+	}
+
+	if err := dbManager.InitaliseDatabase(context.Background()); err != nil {
+		logf.Log.Error(err, "failed to initialise database")
+		os.Exit(1)
+	}
+
+	id := uuid.NewString()
+	taskAllocator := workers.NewTaskAllocator(clientset, id)
+
+	// Create a simple in-memory queue for the worker
+	que := queue.NewMemoryQueue(context.Background())
+
+	// Create a log store (filesystem by default)
+	logStore, err := object.NewFileSystemLogStore("/tmp/kontroler-logs")
+	if err != nil {
+		logf.Log.Error(err, "failed to create log store (proceeding without log collection)")
+		logStore = nil
+	}
+
+	// webhook channel
+	webhookChan := make(chan webhook.WebhookPayload, 10)
+
+	// parse poll duration
+	pollDuration, err := time.ParseDuration(pollDurationStr)
+	if err != nil {
+		pollDuration = 100 * time.Millisecond
+	}
+
+	w := workers.NewWorker(que, logStore, webhookChan, dbManager, clientset, taskAllocator, pollDuration)
+
+	// Start worker
+	if err := w.Run(ctx); err != nil {
+		logf.Log.Error(err, "worker stopped with error")
+		os.Exit(1)
+	}
+
+	<-ctx.Done()
+	fmt.Println("worker exiting")
+}

--- a/controller/config/crd/bases/kontroler.greedykomodo_workerpools.yaml
+++ b/controller/config/crd/bases/kontroler.greedykomodo_workerpools.yaml
@@ -1,0 +1,63 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workerpools.kontroler.greedykomodo
+spec:
+  group: kontroler.greedykomodo
+  names:
+    kind: WorkerPool
+    plural: workerpools
+    singular: workerpool
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                image:
+                  type: string
+                concurrency:
+                  type: object
+                  properties:
+                    maxConcurrentClaims:
+                      type: integer
+                    claimBatchSize:
+                      type: integer
+                lease:
+                  type: object
+                  properties:
+                    ttlSeconds:
+                      type: integer
+                podTemplate:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                dbSecretRef:
+                  type: string
+                metrics:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                    scrapePort:
+                      type: integer
+                gracefulShutdownSeconds:
+                  type: integer
+            status:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                readyReplicas:
+                  type: integer
+                lastReconcileTime:
+                  type: string
+      subresources:
+        status: {}

--- a/controller/config/rbac/role.yaml
+++ b/controller/config/rbac/role.yaml
@@ -5,6 +5,61 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - kontroler.greedykomodo
   resources:
   - dagruns
@@ -78,6 +133,26 @@ rules:
   - kontroler.greedykomodo
   resources:
   - dagtasks/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kontroler.greedykomodo
+  resources:
+  - workerpools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kontroler.greedykomodo
+  resources:
+  - workerpools/status
   verbs:
   - get
   - patch

--- a/controller/config/samples/kontroler_v1alpha1_workerpool.yaml
+++ b/controller/config/samples/kontroler_v1alpha1_workerpool.yaml
@@ -1,0 +1,34 @@
+# Sample WorkerPool that uses the worker image built from controller/Dockerfile.worker
+# Build & tag the worker image locally before applying:
+#   cd controller
+#   docker build -t greedykomodo/kontroler-worker:latest -f Dockerfile.worker .
+#   docker push greedykomodo/kontroler-worker:latest    # (optional) push to your registry
+
+apiVersion: kontroler.greedykomodo/v1alpha1
+kind: WorkerPool
+metadata:
+  name: sample-workerpool
+  namespace: default
+spec:
+  # Desired number of worker replicas
+  replicas: 1
+
+  # Image built from controller/Dockerfile.worker
+  image: greedykomodo/kontroler-worker:latest
+
+  # Optional: podTemplate will be merged into the generated Deployment's pod spec
+  podTemplate:
+    serviceAccountName: default
+    nodeSelector:
+      # change or remove to match your cluster nodes
+      "node-role.kubernetes.io/worker": "true"
+    # Example: pass a DB secret name if your worker needs DB access
+    # dbSecretRef: kontroler-db-secret
+
+  # Optional graceful shutdown window (seconds)
+  gracefulShutdownSeconds: 30
+
+# Notes:
+# - Ensure the WorkerPool CRD is installed (chart/crds or make deploy installs it).
+# - This example assumes the controller will create a Deployment named <name>-workers
+#   and will use the container image specified above (built from controller/Dockerfile.worker).

--- a/controller/internal/controller/dagrun_controller.go
+++ b/controller/internal/controller/dagrun_controller.go
@@ -103,18 +103,6 @@ func (r *DagRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
-	// Check if a DagRun with the same parameters already exists
-	alreadyExists, err := r.DbManager.FindExistingDAGRun(ctx, dagRun.Name)
-	if err != nil {
-		log.Log.Error(err, "failed to check for existing DagRun", "dag_id", dagRun.Spec.DagName)
-		return ctrl.Result{}, err
-	}
-
-	if alreadyExists {
-		// log.Log.Info("DagRun with the same name already exists", "dagRun_id", dagRun.Spec.DagName, "dag_name", dagRun.Name)
-		return ctrl.Result{}, nil
-	}
-
 	parameters, err := r.DbManager.GetDagParameters(ctx, dagRun.Spec.DagName)
 	if err != nil {
 		log.Log.Error(err, "failed to find parameters", "dag_id", dagRun.Spec.DagName)
@@ -186,6 +174,16 @@ func (r *DagRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 					task.Parameters[i].Value = param.Value
 				}
 			}
+		}
+
+		exists, err := r.DbManager.TaskRunExists(ctx, runId, task.Id)
+		if err != nil {
+			log.Log.Error(err, "failed to check for existing pending task run", "dag_id", dagRun.Spec.DagName, "task_id", task.Id)
+			return ctrl.Result{}, err
+		}
+		if exists {
+			log.Log.Info("pending task run already exists, skipping", "dag_id", dagRun.Spec.DagName, "task_id", task.Id, "runId", runId)
+			continue
 		}
 
 		taskRunId, err := r.DbManager.AddPendingTaskRun(ctx, runId, task.Id)
@@ -283,17 +281,12 @@ func (r *DagRunReconciler) handleDeletion(ctx context.Context, dagRun *kontroler
 		return ctrl.Result{}, err
 	}
 
-	// Remove the finalizer
-	old := dagRun.DeepCopy()
-	dagRun.Finalizers = removeString(dagRun.Finalizers, dagRunFinalizer)
-	if err := r.Patch(ctx, dagRun, client.MergeFrom(old)); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// remove logs
-	if err := r.LogStore.DeleteLogs(ctx, dagRun.Status.DagRunId); err != nil {
-		log.Log.Error(err, "failed to delete logs", "dagRunId", dagRun.Status.DagRunId)
-		return ctrl.Result{}, err
+	if r.LogStore != nil {
+		if err := r.LogStore.DeleteLogs(ctx, dagRun.Status.DagRunId); err != nil {
+			log.Log.Error(err, "failed to delete logs", "dagRunId", dagRun.Status.DagRunId)
+			return ctrl.Result{}, err
+		}
 	}
 
 	// delete the PVC
@@ -303,6 +296,13 @@ func (r *DagRunReconciler) handleDeletion(ctx context.Context, dagRun *kontroler
 			log.Log.Error(err, "failed to delete pvc", "pvcName", pvcName, "namespace", dagRun.Namespace)
 			return ctrl.Result{}, err
 		}
+	}
+
+	// Remove the finalizer only after all cleanup succeeded.
+	old := dagRun.DeepCopy()
+	dagRun.Finalizers = removeString(dagRun.Finalizers, dagRunFinalizer)
+	if err := r.Patch(ctx, dagRun, client.MergeFrom(old)); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/controller/internal/controller/workerpool_controller.go
+++ b/controller/internal/controller/workerpool_controller.go
@@ -1,0 +1,404 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kontrolerv1alpha1 "kontroler-controller/api/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	log "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// WorkerPoolReconciler reconciles a WorkerPool object
+type WorkerPoolReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+const (
+	workerPoolFinalizer = "workerpool.finalizers.kontroler.greedykomodo"
+)
+
+//+kubebuilder:rbac:groups=kontroler.greedykomodo,resources=workerpools,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=kontroler.greedykomodo,resources=workerpools/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+
+func (r *WorkerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx).WithName("workerpool-reconciler").WithValues("workerpool", req.NamespacedName)
+
+	var wp kontrolerv1alpha1.WorkerPool
+	if err := r.Get(ctx, req.NamespacedName, &wp); err != nil {
+		// resource not found or other error
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// default replicas
+	replicas := int32(1)
+	if wp.Spec.Replicas != nil {
+		replicas = *wp.Spec.Replicas
+	}
+
+	// ensure service account + role + rolebinding exist for worker pods
+	defaultSA := ""
+	if wp.Spec.PodTemplate == nil || wp.Spec.PodTemplate.ServiceAccountName == "" {
+		saName, err := r.ensureWorkerRBAC(ctx, &wp)
+		if err != nil {
+			log.Error(err, "failed to ensure worker RBAC resources")
+			return ctrl.Result{}, err
+		}
+		defaultSA = saName
+	}
+
+	// construct desired Deployment
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      wp.Name + "-workers",
+			Namespace: wp.Namespace,
+			Labels: map[string]string{
+				"app":        "kontroler-worker",
+				"workerpool": wp.Name,
+			},
+		},
+	}
+
+	// Ensure the selector is set to match the labels (required by k8s)
+	dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: dep.Labels}
+
+	// Ensure finalizer present on create/update
+	if dep == nil {
+		dep = &appsv1.Deployment{}
+	}
+
+	if dep.ObjectMeta.Annotations == nil {
+		dep.ObjectMeta.Annotations = map[string]string{}
+	}
+
+	// Add finalizer to WorkerPool if not present
+	if wp.ObjectMeta.DeletionTimestamp.IsZero() {
+		if !containsString(wp.ObjectMeta.Finalizers, workerPoolFinalizer) {
+			wp.ObjectMeta.Finalizers = append(wp.ObjectMeta.Finalizers, workerPoolFinalizer)
+			if err := r.Update(ctx, &wp); err != nil {
+				log.Error(err, "failed to add finalizer to WorkerPool")
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	// If deletion timestamp is set, handle graceful shutdown
+	if !wp.ObjectMeta.DeletionTimestamp.IsZero() {
+		// reconcile deletion: scale deployment to zero and wait for pods to terminate
+		var existing appsv1.Deployment
+		if err := r.Get(ctx, types.NamespacedName{Name: wp.Name + "-workers", Namespace: wp.Namespace}, &existing); err == nil {
+			zero := int32(0)
+			if existing.Spec.Replicas == nil || *existing.Spec.Replicas != 0 {
+				existing.Spec.Replicas = &zero
+				if err := r.Update(ctx, &existing); err != nil {
+					log.Error(err, "failed to scale deployment to zero during WorkerPool deletion")
+					return ctrl.Result{}, err
+				}
+			}
+
+			// if readyReplicas still > 0, requeue and wait
+			if existing.Status.ReadyReplicas > 0 {
+				log.Info("waiting for deployment readyReplicas to become 0 before removing finalizer", "readyReplicas", existing.Status.ReadyReplicas)
+				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			}
+
+			// remove finalizer and allow deletion to continue
+			wp.ObjectMeta.Finalizers = removeString(wp.ObjectMeta.Finalizers, workerPoolFinalizer)
+			if err := r.Update(ctx, &wp); err != nil {
+				log.Error(err, "failed to remove finalizer from WorkerPool")
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{}, nil
+		}
+		// if deployment not found, simply remove finalizer
+		if containsString(wp.ObjectMeta.Finalizers, workerPoolFinalizer) {
+			wp.ObjectMeta.Finalizers = removeString(wp.ObjectMeta.Finalizers, workerPoolFinalizer)
+			if err := r.Update(ctx, &wp); err != nil {
+				log.Error(err, "failed to remove finalizer from WorkerPool (no deployment present)")
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	opResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, dep, func() error {
+		// set owner
+		if err := controllerutil.SetControllerReference(&wp, dep, r.Scheme); err != nil {
+			return err
+		}
+
+		dep.Spec.Replicas = &replicas
+		// Pod template
+		var containerImage string
+		if wp.Spec.Image != "" {
+			containerImage = wp.Spec.Image
+		} else {
+			containerImage = "greedykomodo/kontroler-worker:latest"
+		}
+
+		// default envs and mapping
+		envs := []corev1.EnvVar{
+			{Name: "WORKERPOOL_NAME", Value: wp.Name},
+		}
+
+		// propagate DB settings from controller environment into worker pods for distributed mode
+		// If the controller is configured with DB envs (via Helm), copy them so workers can connect
+		if dbType := os.Getenv("DB_TYPE"); dbType != "" {
+			envs = append(envs, corev1.EnvVar{Name: "DB_TYPE", Value: dbType})
+		}
+		if dbEndpoint := os.Getenv("DB_ENDPOINT"); dbEndpoint != "" {
+			envs = append(envs, corev1.EnvVar{Name: "DB_ENDPOINT", Value: dbEndpoint})
+		}
+		if dbName := os.Getenv("DB_NAME"); dbName != "" {
+			envs = append(envs, corev1.EnvVar{Name: "DB_NAME", Value: dbName})
+		}
+		if dbUser := os.Getenv("DB_USER"); dbUser != "" {
+			envs = append(envs, corev1.EnvVar{Name: "DB_USER", Value: dbUser})
+		}
+		// DB_PASSWORD via secret reference; prefer env var DB_PASSWORD_SECRET else default to postgres-postgresql
+		secretName := os.Getenv("DB_PASSWORD_SECRET")
+		if secretName == "" {
+			secretName = "postgres-postgresql"
+		}
+		secretKey := os.Getenv("DB_PASSWORD_KEY")
+		if secretKey == "" {
+			secretKey = "postgres-password"
+		}
+		// Add DB_PASSWORD env var from secret if secret exists in cluster
+		envs = append(envs, corev1.EnvVar{
+			Name: "DB_PASSWORD",
+			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+				Key:                  secretKey,
+			}},
+		})
+
+		if wp.Spec.Concurrency != nil {
+			if wp.Spec.Concurrency.ClaimBatchSize != nil {
+				envs = append(envs, corev1.EnvVar{Name: "CLAIM_BATCH_SIZE", Value: fmtIntPtr(wp.Spec.Concurrency.ClaimBatchSize)})
+			}
+			if wp.Spec.Concurrency.MaxConcurrentClaims != nil {
+				envs = append(envs, corev1.EnvVar{Name: "MAX_CONCURRENT_CLAIMS", Value: fmtIntPtr(wp.Spec.Concurrency.MaxConcurrentClaims)})
+			}
+		}
+
+		if wp.Spec.Lease != nil && wp.Spec.Lease.TTLSeconds != nil {
+			envs = append(envs, corev1.EnvVar{Name: "DEFAULT_LEASE_TTL_SECONDS", Value: fmtIntPtr(wp.Spec.Lease.TTLSeconds)})
+		}
+
+		// mount DB secret name as env var reference if provided
+		if wp.Spec.DBSecretRef != "" {
+			envs = append(envs, corev1.EnvVar{Name: "DB_SECRET_NAME", Value: wp.Spec.DBSecretRef})
+		}
+
+		// build container spec
+		// ensure selector matches labels
+		dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: dep.Labels}
+		dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{Labels: dep.Labels}
+		dep.Spec.Template.Spec = corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "worker",
+					Image:           containerImage,
+					Env:             envs,
+					Ports:           []corev1.ContainerPort{{ContainerPort: 9100, Name: "metrics"}},
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				},
+			},
+		}
+
+		// merge PodTemplate from spec if provided
+		if wp.Spec.PodTemplate != nil {
+			pt := wp.Spec.PodTemplate
+
+			// node selector
+			if pt.NodeSelector != nil {
+				dep.Spec.Template.Spec.NodeSelector = pt.NodeSelector
+			}
+
+			// service account
+			if pt.ServiceAccountName != "" {
+				dep.Spec.Template.Spec.ServiceAccountName = pt.ServiceAccountName
+			} else if defaultSA != "" {
+				dep.Spec.Template.Spec.ServiceAccountName = defaultSA
+			}
+
+			// automount service account token
+			if pt.AutomountServiceAccountToken != nil {
+				a := *pt.AutomountServiceAccountToken
+				dep.Spec.Template.Spec.AutomountServiceAccountToken = &a
+			}
+
+			// active deadline seconds
+			if pt.ActiveDeadlineSeconds != nil {
+				dep.Spec.Template.Spec.ActiveDeadlineSeconds = pt.ActiveDeadlineSeconds
+			}
+
+			// image pull secrets
+			if len(pt.ImagePullSecrets) > 0 {
+				ips := make([]corev1.LocalObjectReference, 0, len(pt.ImagePullSecrets))
+				for _, s := range pt.ImagePullSecrets {
+					ips = append(ips, corev1.LocalObjectReference{Name: s.Name})
+				}
+				dep.Spec.Template.Spec.ImagePullSecrets = ips
+			}
+
+			// tolerations
+			if len(pt.Tolerations) > 0 {
+				tols := make([]corev1.Toleration, 0, len(pt.Tolerations))
+				for _, t := range pt.Tolerations {
+					tols = append(tols, corev1.Toleration{
+						Key:               t.Key,
+						Operator:          corev1.TolerationOperator(t.Operator),
+						Value:             t.Value,
+						Effect:            corev1.TaintEffect(t.Effect),
+						TolerationSeconds: t.TolerationSeconds,
+					})
+				}
+				dep.Spec.Template.Spec.Tolerations = tols
+			}
+
+			// volumes
+			if len(pt.Volumes) > 0 {
+				vols := dep.Spec.Template.Spec.Volumes
+				for _, v := range pt.Volumes {
+					vol := corev1.Volume{Name: v.Name}
+					if v.EmptyDir != nil {
+						vol.VolumeSource = corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}
+					} else if v.PersistentVolumeClaim != nil {
+						vol.VolumeSource = corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: v.PersistentVolumeClaim.ClaimName}}
+					}
+					vols = append(vols, vol)
+				}
+				dep.Spec.Template.Spec.Volumes = vols
+			}
+
+			// container volume mounts
+			if len(pt.VolumeMounts) > 0 {
+				mounts := dep.Spec.Template.Spec.Containers[0].VolumeMounts
+				for _, vm := range pt.VolumeMounts {
+					mounts = append(mounts, corev1.VolumeMount{Name: vm.Name, MountPath: vm.MountPath, ReadOnly: vm.ReadOnly})
+				}
+				dep.Spec.Template.Spec.Containers[0].VolumeMounts = mounts
+			}
+
+			// security context (only FSGroup supported)
+			if pt.SecurityContext != nil {
+				psc := &corev1.PodSecurityContext{}
+				if pt.SecurityContext.FSGroup != nil {
+					psc.FSGroup = pt.SecurityContext.FSGroup
+				}
+				dep.Spec.Template.Spec.SecurityContext = psc
+			}
+
+			// resources for the first container if provided
+			if pt.Resources != nil {
+				req := corev1.ResourceList{}
+				lim := corev1.ResourceList{}
+				for k, v := range pt.Resources.Requests {
+					if r, err := resource.ParseQuantity(v); err == nil {
+						req[corev1.ResourceName(k)] = r
+					}
+				}
+				for k, v := range pt.Resources.Limits {
+					if r, err := resource.ParseQuantity(v); err == nil {
+						lim[corev1.ResourceName(k)] = r
+					}
+				}
+				if dep.Spec.Template.Spec.Containers[0].Resources.Requests == nil {
+					dep.Spec.Template.Spec.Containers[0].Resources.Requests = req
+				} else {
+					for k, q := range req {
+						dep.Spec.Template.Spec.Containers[0].Resources.Requests[k] = q
+					}
+				}
+				if dep.Spec.Template.Spec.Containers[0].Resources.Limits == nil {
+					dep.Spec.Template.Spec.Containers[0].Resources.Limits = lim
+				} else {
+					for k, q := range lim {
+						dep.Spec.Template.Spec.Containers[0].Resources.Limits[k] = q
+					}
+				}
+			}
+
+			// affinity: provided as raw JSON; attempt to unmarshal into corev1.Affinity parts
+			if pt.Affinity != nil {
+				var af corev1.Affinity
+				// nodeAffinity
+				if pt.Affinity.NodeAffinity != nil {
+					_ = json.Unmarshal(pt.Affinity.NodeAffinity.Raw, &af.NodeAffinity)
+				}
+				if pt.Affinity.PodAffinity != nil {
+					_ = json.Unmarshal(pt.Affinity.PodAffinity.Raw, &af.PodAffinity)
+				}
+				if pt.Affinity.PodAntiAffinity != nil {
+					_ = json.Unmarshal(pt.Affinity.PodAntiAffinity.Raw, &af.PodAntiAffinity)
+				}
+				dep.Spec.Template.Spec.Affinity = &af
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		log.Error(err, "failed to create or update deployment")
+		return ctrl.Result{}, err
+	}
+
+	// update status
+	wp.Status.Replicas = replicas
+	// fetch ready replicas
+	var curr appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Name: dep.Name, Namespace: dep.Namespace}, &curr); err == nil {
+		wp.Status.ReadyReplicas = curr.Status.ReadyReplicas
+		t := metav1.NewTime(time.Now())
+		wp.Status.LastReconcileTime = &t
+		_ = r.Status().Update(ctx, &wp)
+	}
+
+	// Ensure finalizer is present on the resource if not deleting
+	if wp.ObjectMeta.DeletionTimestamp.IsZero() && !containsString(wp.ObjectMeta.Finalizers, workerPoolFinalizer) {
+		wp.ObjectMeta.Finalizers = append(wp.ObjectMeta.Finalizers, workerPoolFinalizer)
+		if err := r.Update(ctx, &wp); err != nil {
+			log.Error(err, "failed to add finalizer to WorkerPool during reconcile")
+			return ctrl.Result{}, err
+		}
+	}
+
+	log.Info("reconciled workerpool", "name", wp.Name, "result", opResult)
+	return ctrl.Result{}, nil
+}
+
+func (r *WorkerPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&kontrolerv1alpha1.WorkerPool{}).
+		Owns(&appsv1.Deployment{}).
+		Complete(r)
+}
+
+// helper functions (small adapters)
+func fmtIntPtr(p *int32) string {
+	if p == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d", *p)
+}

--- a/controller/internal/controller/workerpool_controller_test.go
+++ b/controller/internal/controller/workerpool_controller_test.go
@@ -1,0 +1,366 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	kontrolerv1alpha1 "kontroler-controller/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("WorkerPool Controller", func() {
+	Context("When reconciling a WorkerPool resource", func() {
+		const resourceName = "test-workerpool"
+		ctx := context.Background()
+		nn := types.NamespacedName{Name: resourceName, Namespace: "default"}
+
+		BeforeEach(func() {
+			wp := &kontrolerv1alpha1.WorkerPool{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: "default"},
+				Spec: kontrolerv1alpha1.WorkerPoolSpec{
+					Replicas: ptrInt32(1),
+					Image:    "busybox:latest",
+					Concurrency: &struct {
+						MaxConcurrentClaims *int32 "json:\"maxConcurrentClaims,omitempty\""
+						ClaimBatchSize      *int32 "json:\"claimBatchSize,omitempty\""
+					}{
+						MaxConcurrentClaims: ptrInt32(5),
+						ClaimBatchSize:      ptrInt32(2),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, wp)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			wp := &kontrolerv1alpha1.WorkerPool{}
+			_ = k8sClient.Get(ctx, nn, wp)
+			_ = k8sClient.Delete(ctx, wp)
+		})
+
+		It("should create a Deployment for the WorkerPool", func() {
+			reconciler := &WorkerPoolReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+
+			// give controller-runtime fake client a moment to persist
+			// then retrieve Deployment
+			dep := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: resourceName + "-workers", Namespace: "default"}, dep)
+			}, 5*time.Second, 250*time.Millisecond).Should(Succeed())
+			Expect(dep.Spec.Replicas).NotTo(BeNil())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(1)))
+		})
+
+		It("should merge PodTemplate into generated Deployment", func() {
+			// create a WorkerPool with rich PodTemplate
+			n := "test-podtemplate"
+			nn2 := types.NamespacedName{Name: n, Namespace: "default"}
+			nodeSel := map[string]string{"node-role.kubernetes.io/worker": "true"}
+			ips := []kontrolerv1alpha1.LocalObjectReference{{Name: "my-pull-secret"}}
+			mountName := "workspace"
+			volumes := []kontrolerv1alpha1.Volume{{Name: mountName, PersistentVolumeClaim: &kontrolerv1alpha1.PersistentVolumeClaimVolumeSource{ClaimName: "my-claim"}}}
+			vms := []kontrolerv1alpha1.VolumeMount{{Name: mountName, MountPath: "/workspace", ReadOnly: false}}
+			fs := int64(1000)
+			resources := &kontrolerv1alpha1.ResourceRequirements{
+				Requests: map[string]string{"cpu": "100m", "memory": "128Mi"},
+				Limits:   map[string]string{"cpu": "500m", "memory": "512Mi"},
+			}
+
+			// build an affinity JSON
+			aff := &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{},
+			}
+			affJSON, _ := json.Marshal(aff)
+			affWrapper := &kontrolerv1alpha1.Affinity{
+				NodeAffinity: &apiextensionsv1.JSON{Raw: affJSON},
+			}
+
+			wp := &kontrolerv1alpha1.WorkerPool{
+				ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: "default"},
+				Spec: kontrolerv1alpha1.WorkerPoolSpec{
+					Replicas: ptrInt32(1),
+					Image:    "busybox:latest",
+					PodTemplate: &kontrolerv1alpha1.PodTemplateSpec{
+						NodeSelector:                 nodeSel,
+						ServiceAccountName:           "sa-name",
+						AutomountServiceAccountToken: ptrBool(true),
+						ActiveDeadlineSeconds:        ptrInt64(120),
+						ImagePullSecrets:             ips,
+						Tolerations:                  []kontrolerv1alpha1.Toleration{{Key: "k1", Operator: "Equal", Value: "v1", Effect: "NoSchedule"}},
+						Volumes:                      volumes,
+						VolumeMounts:                 vms,
+						SecurityContext:              &kontrolerv1alpha1.PodSecurityContext{FSGroup: &fs},
+						Resources:                    resources,
+						Affinity:                     affWrapper,
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, wp)).To(Succeed())
+
+			reconciler := &WorkerPoolReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nn2})
+			Expect(err).NotTo(HaveOccurred())
+
+			dep := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: n + "-workers", Namespace: "default"}, dep)
+			}, 5*time.Second, 250*time.Millisecond).Should(Succeed())
+
+			// assertions
+			Expect(dep.Spec.Template.Spec.NodeSelector).To(Equal(nodeSel))
+			Expect(dep.Spec.Template.Spec.ServiceAccountName).To(Equal("sa-name"))
+			Expect(*dep.Spec.Template.Spec.AutomountServiceAccountToken).To(BeTrue())
+			Expect(dep.Spec.Template.Spec.ActiveDeadlineSeconds).NotTo(BeNil())
+			Expect(*dep.Spec.Template.Spec.ActiveDeadlineSeconds).To(Equal(int64(120)))
+			// image pull secret
+			Expect(len(dep.Spec.Template.Spec.ImagePullSecrets)).To(Equal(1))
+			Expect(dep.Spec.Template.Spec.ImagePullSecrets[0].Name).To(Equal("my-pull-secret"))
+			// tolerations
+			Expect(len(dep.Spec.Template.Spec.Tolerations)).To(Equal(1))
+			Expect(dep.Spec.Template.Spec.Tolerations[0].Key).To(Equal("k1"))
+			// volumes
+			found := false
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName == "my-claim" {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue())
+			// volume mounts
+			Expect(len(dep.Spec.Template.Spec.Containers[0].VolumeMounts)).To(BeNumerically(">=", 1))
+			// security context
+			Expect(dep.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
+			Expect(dep.Spec.Template.Spec.SecurityContext.FSGroup).NotTo(BeNil())
+			Expect(*dep.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(int64(1000)))
+			// resources
+			reqs := dep.Spec.Template.Spec.Containers[0].Resources.Requests
+			Expect(reqs[corev1.ResourceCPU].String()).To(Equal("100m"))
+			Expect(reqs[corev1.ResourceMemory].String()).To(Equal("128Mi"))
+			// affinity presence
+			Expect(dep.Spec.Template.Spec.Affinity).NotTo(BeNil())
+		})
+
+		It("should add finalizer on create", func() {
+			// create simple WP
+			n := "test-finalizer"
+			nnF := types.NamespacedName{Name: n, Namespace: "default"}
+			wp := &kontrolerv1alpha1.WorkerPool{
+				ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: "default"},
+				Spec: kontrolerv1alpha1.WorkerPoolSpec{
+					Replicas: ptrInt32(1),
+				},
+			}
+			Expect(k8sClient.Create(ctx, wp)).To(Succeed())
+
+			reconciler := &WorkerPoolReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nnF})
+			Expect(err).NotTo(HaveOccurred())
+
+			// fetch and assert finalizer present
+			got := &kontrolerv1alpha1.WorkerPool{}
+			Expect(k8sClient.Get(ctx, nnF, got)).To(Succeed())
+			Expect(containsString(got.ObjectMeta.Finalizers, workerPoolFinalizer)).To(BeTrue())
+		})
+
+		It("should scale down and remove finalizer on deletion", func() {
+			// create WP
+			n := "test-delete"
+			nn3 := types.NamespacedName{Name: n, Namespace: "default"}
+			wp := &kontrolerv1alpha1.WorkerPool{
+				ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: "default"},
+				Spec: kontrolerv1alpha1.WorkerPoolSpec{
+					Replicas:                ptrInt32(1),
+					GracefulShutdownSeconds: ptrInt32(30),
+				},
+			}
+			Expect(k8sClient.Create(ctx, wp)).To(Succeed())
+
+			reconciler := &WorkerPoolReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nn3})
+			Expect(err).NotTo(HaveOccurred())
+
+			// ensure deployment exists
+			dep := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: n + "-workers", Namespace: "default"}, dep)
+			}, 5*time.Second, 250*time.Millisecond).Should(Succeed())
+
+			// simulate ready replicas present
+			dep.Status.ReadyReplicas = 1
+			Expect(k8sClient.Status().Update(ctx, dep)).To(Succeed())
+
+			// delete the WorkerPool (sets deletionTimestamp)
+			Expect(k8sClient.Delete(ctx, wp)).To(Succeed())
+
+			// first reconcile should scale deployment to 0
+			res, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nn3})
+			Expect(err).NotTo(HaveOccurred())
+			// expect reconcile to request a requeue while waiting for pods to drain
+			Expect(res.RequeueAfter).To(BeNumerically(">=", 2*time.Second))
+
+			// fetch deployment and assert replicas = 0
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: n + "-workers", Namespace: "default"}, dep)).To(Succeed())
+			Expect(dep.Spec.Replicas).NotTo(BeNil())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(0)))
+
+			// still has readyReplicas, simulate pods terminated
+			dep.Status.ReadyReplicas = 0
+			Expect(k8sClient.Status().Update(ctx, dep)).To(Succeed())
+
+			// second reconcile should remove finalizer and allow deletion
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nn3})
+			Expect(err).NotTo(HaveOccurred())
+
+			// object should be deleted (not found)
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, nn3, &kontrolerv1alpha1.WorkerPool{})
+				return apierrors.IsNotFound(err)
+			}, 5*time.Second, 250*time.Millisecond).Should(BeTrue())
+		})
+
+		It("should return error when adding finalizer fails", func() {
+			// create WP
+			n := "test-fail-finalizer"
+			nnF := types.NamespacedName{Name: n, Namespace: "default"}
+			wp := &kontrolerv1alpha1.WorkerPool{
+				ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: "default"},
+				Spec:       kontrolerv1alpha1.WorkerPoolSpec{Replicas: ptrInt32(1)},
+			}
+			Expect(k8sClient.Create(ctx, wp)).To(Succeed())
+
+			fcli := newFailingClient(k8sClient)
+			fcli.FailOnUpdateKind("WorkerPool")
+			reconciler := &WorkerPoolReconciler{Client: fcli, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nnF})
+			Expect(err).To(HaveOccurred())
+
+			// fetch original object: finalizer should not be present
+			got := &kontrolerv1alpha1.WorkerPool{}
+			Expect(k8sClient.Get(ctx, nnF, got)).To(Succeed())
+			Expect(containsString(got.ObjectMeta.Finalizers, workerPoolFinalizer)).To(BeFalse())
+		})
+
+		It("should return error when scaling deployment to zero fails", func() {
+			// create WP and reconcile to create deployment
+			n := "test-fail-scale"
+			nnS := types.NamespacedName{Name: n, Namespace: "default"}
+			wp := &kontrolerv1alpha1.WorkerPool{ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: "default"}, Spec: kontrolerv1alpha1.WorkerPoolSpec{Replicas: ptrInt32(1)}}
+			Expect(k8sClient.Create(ctx, wp)).To(Succeed())
+			reconciler := &WorkerPoolReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nnS})
+			Expect(err).NotTo(HaveOccurred())
+
+			// delete WP to set deletionTimestamp
+			Expect(k8sClient.Delete(ctx, wp)).To(Succeed())
+
+			// create failing client that errors on Deployment updates
+			fcli := newFailingClient(k8sClient)
+			fcli.FailOnUpdateKind("Deployment")
+			reconcilerErr := &WorkerPoolReconciler{Client: fcli, Scheme: k8sClient.Scheme()}
+			_, err = reconcilerErr.Reconcile(ctx, ctrl.Request{NamespacedName: nnS})
+			Expect(err).To(HaveOccurred())
+
+			// finalizer should still be present
+			got := &kontrolerv1alpha1.WorkerPool{}
+			Expect(k8sClient.Get(ctx, nnS, got)).To(Succeed())
+			Expect(containsString(got.ObjectMeta.Finalizers, workerPoolFinalizer)).To(BeTrue())
+		})
+
+		It("should return error when removing finalizer fails", func() {
+			// create WP and reconcile to create deployment
+			n := "test-fail-remove-finalizer"
+			nnR := types.NamespacedName{Name: n, Namespace: "default"}
+			wp := &kontrolerv1alpha1.WorkerPool{ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: "default"}, Spec: kontrolerv1alpha1.WorkerPoolSpec{Replicas: ptrInt32(1)}}
+			Expect(k8sClient.Create(ctx, wp)).To(Succeed())
+			reconciler := &WorkerPoolReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nnR})
+			Expect(err).NotTo(HaveOccurred())
+
+			// simulate deployment ready=0
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: n + "-workers", Namespace: "default"}, dep)).To(Succeed())
+			// delete WP
+			Expect(k8sClient.Delete(ctx, wp)).To(Succeed())
+			// set dep ready replicas to 0 to allow finalizer removal path
+			dep.Status.ReadyReplicas = 0
+			Expect(k8sClient.Status().Update(ctx, dep)).To(Succeed())
+
+			// failing client that errors when updating WorkerPool (removing finalizer)
+			fcli := newFailingClient(k8sClient)
+			fcli.FailOnUpdateKind("WorkerPool")
+			reconcilerErr := &WorkerPoolReconciler{Client: fcli, Scheme: k8sClient.Scheme()}
+			_, err = reconcilerErr.Reconcile(ctx, ctrl.Request{NamespacedName: nnR})
+			Expect(err).To(HaveOccurred())
+
+			// finalizer should still be present
+			got := &kontrolerv1alpha1.WorkerPool{}
+			Expect(k8sClient.Get(ctx, nnR, got)).To(Succeed())
+			Expect(containsString(got.ObjectMeta.Finalizers, workerPoolFinalizer)).To(BeTrue())
+		})
+
+	})
+})
+
+// helper ptrs
+func ptrInt32(i int32) *int32 { return &i }
+
+func ptrInt64(i int64) *int64 { return &i }
+
+func ptrBool(b bool) *bool { return &b }
+
+// failingClient wraps a real client and injects failures for Update on specific resources
+type failingClient struct {
+	client.Client
+	failOnUpdateNames map[string]struct{}
+	failOnUpdateKinds map[string]struct{}
+}
+
+func newFailingClient(base client.Client) *failingClient {
+	return &failingClient{Client: base, failOnUpdateNames: map[string]struct{}{}, failOnUpdateKinds: map[string]struct{}{}}
+}
+
+func (f *failingClient) FailOnUpdateName(name string) { f.failOnUpdateNames[name] = struct{}{} }
+func (f *failingClient) FailOnUpdateKind(kind string) { f.failOnUpdateKinds[kind] = struct{}{} }
+
+func (f *failingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	// name-based failure
+	if obj != nil {
+		if accessor, err := meta.Accessor(obj); err == nil {
+			if _, ok := f.failOnUpdateNames[accessor.GetName()]; ok {
+				return fmt.Errorf("injected update error for name %s", accessor.GetName())
+			}
+		}
+	}
+
+	// kind/type based failure
+	switch obj.(type) {
+	case *kontrolerv1alpha1.WorkerPool:
+		if _, ok := f.failOnUpdateKinds["WorkerPool"]; ok {
+			return fmt.Errorf("injected update error for kind WorkerPool")
+		}
+	case *appsv1.Deployment:
+		if _, ok := f.failOnUpdateKinds["Deployment"]; ok {
+			return fmt.Errorf("injected update error for kind Deployment")
+		}
+	}
+
+	return f.Client.Update(ctx, obj, opts...)
+}

--- a/controller/internal/controller/workerpool_controller_test.go
+++ b/controller/internal/controller/workerpool_controller_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	kontrolerv1alpha1 "kontroler-controller/api/v1alpha1"
-	"sigs.k8s.io/controller-runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -152,8 +151,10 @@ var _ = Describe("WorkerPool Controller", func() {
 			Expect(*dep.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(int64(1000)))
 			// resources
 			reqs := dep.Spec.Template.Spec.Containers[0].Resources.Requests
-			Expect(reqs[corev1.ResourceCPU].String()).To(Equal("100m"))
-			Expect(reqs[corev1.ResourceMemory].String()).To(Equal("128Mi"))
+			cpu := reqs[corev1.ResourceCPU]
+			memory := reqs[corev1.ResourceMemory]
+			Expect(cpu.String()).To(Equal("100m"))
+			Expect(memory.String()).To(Equal("128Mi"))
 			// affinity presence
 			Expect(dep.Spec.Template.Spec.Affinity).NotTo(BeNil())
 		})

--- a/controller/internal/controller/workerpool_rbac.go
+++ b/controller/internal/controller/workerpool_rbac.go
@@ -1,0 +1,65 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kontrolerv1alpha1 "kontroler-controller/api/v1alpha1"
+)
+
+// ensureWorkerRBAC creates a ServiceAccount, Role and RoleBinding in the WorkerPool namespace
+// and returns the name of the ServiceAccount to use. If a ServiceAccount already exists it is left intact.
+func (r *WorkerPoolReconciler) ensureWorkerRBAC(ctx context.Context, wp *kontrolerv1alpha1.WorkerPool) (string, error) {
+	// choose SA name
+	saName := wp.Name + "-sa"
+	roleName := wp.Name + "-pod-ops"
+	rbName := wp.Name + "-pod-ops-binding"
+
+	// create or update ServiceAccount
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: wp.Namespace},
+	}
+	if err := controllerutil.SetControllerReference(wp, sa, r.Scheme); err != nil {
+		return "", err
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error { return nil }); err != nil {
+		return "", fmt.Errorf("failed to create or update serviceaccount: %w", err)
+	}
+
+	// create or update Role with pod permissions (namespace-scoped)
+	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: wp.Namespace}}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, role, func() error {
+		role.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods/exec"},
+				Verbs:     []string{"create"},
+			},
+		}
+		return nil
+	}); err != nil {
+		return "", fmt.Errorf("failed to create or update role: %w", err)
+	}
+
+	// create or update RoleBinding to bind role -> serviceaccount
+	rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbName, Namespace: wp.Namespace}}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, rb, func() error {
+		rb.Subjects = []rbacv1.Subject{{Kind: "ServiceAccount", Name: saName, Namespace: wp.Namespace}}
+		rb.RoleRef = rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: roleName}
+		return nil
+	}); err != nil {
+		return "", fmt.Errorf("failed to create or update rolebinding: %w", err)
+	}
+
+	return saName, nil
+}

--- a/controller/internal/db/dbManagers.go
+++ b/controller/internal/db/dbManagers.go
@@ -55,6 +55,8 @@ type DBDAGManager interface {
 	CreateDAGRun(ctx context.Context, name string, dag *v1alpha1.DagRunSpec, parameters map[string]v1alpha1.ParameterSpec, pvcName *string) (int, error)
 	// Get all the tasks in the DAG that do not have any dependencies
 	GetStartingTasks(ctx context.Context, dagName string, dagrun int) ([]Task, error)
+	// TaskRunExists reports whether a Task_Run row already exists for the run/task pair.
+	TaskRunExists(ctx context.Context, runId, dagTaskId int) (bool, error)
 	// Add an update to show the task has been started
 	MarkTaskAsStarted(ctx context.Context, runId, taskId int) (int, error)
 	// Mark the outcome of the taskRun

--- a/controller/internal/db/postgresDAGManager.go
+++ b/controller/internal/db/postgresDAGManager.go
@@ -352,6 +352,13 @@ func (p *postgresDAGManager) CreateDAGRun(ctx context.Context, name string, dag 
 		return 0, err
 	}
 
+	var existingRunID int
+	if err := p.pool.QueryRow(ctx, `SELECT run_id FROM DAG_Runs WHERE name = $1`, name).Scan(&existingRunID); err == nil {
+		return existingRunID, nil
+	} else if err != pgx.ErrNoRows {
+		return 0, err
+	}
+
 	var dagRunID int
 	if err := p.withTx(ctx, func(tx pgx.Tx) error {
 		// Map the task to the DAG
@@ -395,6 +402,21 @@ func (p *postgresDAGManager) CreateDAGRun(ctx context.Context, name string, dag 
 	}
 
 	return dagRunID, nil
+}
+
+func (p *postgresDAGManager) TaskRunExists(ctx context.Context, runId, dagTaskId int) (bool, error) {
+	var exists bool
+	if err := p.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM Task_Runs
+			WHERE run_id = $1 AND task_id = $2
+		);
+	`, runId, dagTaskId).Scan(&exists); err != nil {
+		return false, err
+	}
+
+	return exists, nil
 }
 
 func (p *postgresDAGManager) GetStartingTasks(ctx context.Context, dagName string, dagrun int) ([]Task, error) {

--- a/controller/internal/db/postgresMetrics.go
+++ b/controller/internal/db/postgresMetrics.go
@@ -270,6 +270,13 @@ func (m *metricsPostgresDAGManager) CreateDAGRun(ctx context.Context, name strin
 	return result, err
 }
 
+func (m *metricsPostgresDAGManager) TaskRunExists(ctx context.Context, runId, dagTaskId int) (bool, error) {
+	start := time.Now()
+	result, err := m.postgresDAGManager.TaskRunExists(ctx, runId, dagTaskId)
+	m.recordQueryMetrics("select", "task_runs", start, err)
+	return result, err
+}
+
 func (m *metricsPostgresDAGManager) GetStartingTasks(ctx context.Context, dagName string, dagrun int) ([]Task, error) {
 	start := time.Now()
 	result, err := m.postgresDAGManager.GetStartingTasks(ctx, dagName, dagrun)

--- a/controller/internal/db/sqliteManager.go
+++ b/controller/internal/db/sqliteManager.go
@@ -522,6 +522,13 @@ func (s *sqliteDAGManager) CreateDAGRun(ctx context.Context, name string, dag *v
 		return 0, err
 	}
 
+	var existingRunID int
+	if err := s.db.QueryRowContext(ctx, `SELECT run_id FROM DAG_Runs WHERE name = ?`, name).Scan(&existingRunID); err == nil {
+		return existingRunID, nil
+	} else if err != sql.ErrNoRows {
+		return 0, err
+	}
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
@@ -554,6 +561,21 @@ func (s *sqliteDAGManager) CreateDAGRun(ctx context.Context, name string, dag *v
 	}
 
 	return dagRunID, nil
+}
+
+func (s *sqliteDAGManager) TaskRunExists(ctx context.Context, runId, dagTaskId int) (bool, error) {
+	var exists bool
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM Task_Runs
+			WHERE run_id = ? AND task_id = ?
+		);
+	`, runId, dagTaskId).Scan(&exists); err != nil {
+		return false, err
+	}
+
+	return exists, nil
 }
 
 func (s *sqliteDAGManager) dagNameToDagId(ctx context.Context, dagName string) (int, error) {

--- a/controller/internal/db/sqliteMetrics.go
+++ b/controller/internal/db/sqliteMetrics.go
@@ -270,6 +270,13 @@ func (m *MetricsSqliteDAGManager) CreateDAGRun(ctx context.Context, name string,
 	return result, err
 }
 
+func (m *MetricsSqliteDAGManager) TaskRunExists(ctx context.Context, runId, dagTaskId int) (bool, error) {
+	start := time.Now()
+	result, err := m.sqliteDAGManager.TaskRunExists(ctx, runId, dagTaskId)
+	m.recordQueryMetrics("select", "task_runs", start, err)
+	return result, err
+}
+
 func (m *MetricsSqliteDAGManager) GetStartingTasks(ctx context.Context, dagName string, dagrun int) ([]Task, error) {
 	start := time.Now()
 	result, err := m.sqliteDAGManager.GetStartingTasks(ctx, dagName, dagrun)

--- a/controller/internal/object/utils_test.go
+++ b/controller/internal/object/utils_test.go
@@ -1,7 +1,6 @@
 package object
 
 import (
-	"context"
 	"fmt"
 	"testing"
 

--- a/controller/internal/workers/worker_lease_test.go
+++ b/controller/internal/workers/worker_lease_test.go
@@ -28,8 +28,10 @@ func (f *fakeDBLease) GetID(ctx context.Context) (string, error)   { return "fak
 func (f *fakeDBLease) GetDAGsToStartAndUpdate(ctx context.Context, tm time.Time) ([]*db.DagInfo, error) {
 	return nil, nil
 }
-func (f *fakeDBLease) InsertDAG(ctx context.Context, dag *v1.Pod, namespace string) error { return nil }
-func (f *fakeDBLease) CreateDAGRun(ctx context.Context, name string, dag *db.DagRunSpec, parameters map[string]db.Parameter, pvcName *string) (int, error) {
+func (f *fakeDBLease) InsertDAG(ctx context.Context, dag *v1alpha1.DAG, namespace string) error {
+	return nil
+}
+func (f *fakeDBLease) CreateDAGRun(ctx context.Context, name string, dag *v1alpha1.DagRunSpec, parameters map[string]v1alpha1.ParameterSpec, pvcName *string) (int, error) {
 	return 0, nil
 }
 
@@ -69,17 +71,19 @@ func (f *fakeDBLease) FindExistingDAGRun(ctx context.Context, name string) (bool
 func (f *fakeDBLease) GetTaskScriptAndInjectorImage(ctx context.Context, taskId int) (*string, *string, error) {
 	return nil, nil, nil
 }
-func (f *fakeDBLease) AddTask(ctx context.Context, task *v1.Pod, namespace string) error { return nil }
+func (f *fakeDBLease) AddTask(ctx context.Context, task *v1alpha1.DagTask, namespace string) error {
+	return nil
+}
 func (f *fakeDBLease) DeleteTask(ctx context.Context, taskName string, namespace string) error {
 	return nil
 }
-func (f *fakeDBLease) GetTaskRefsParameters(ctx context.Context, taskRefs []db.TaskRef) (map[db.TaskRef][]string, error) {
+func (f *fakeDBLease) GetTaskRefsParameters(ctx context.Context, taskRefs []v1alpha1.TaskRef) (map[v1alpha1.TaskRef][]string, error) {
 	return nil, nil
 }
 func (f *fakeDBLease) GetWebhookDetails(ctx context.Context, dagRunID int) (*v1alpha1.Webhook, error) {
 	return nil, nil
 }
-func (f *fakeDBLease) GetWorkspacePVCTemplate(ctx context.Context, dagId int) (*db.PVC, error) {
+func (f *fakeDBLease) GetWorkspacePVCTemplate(ctx context.Context, dagId int) (*v1alpha1.PVC, error) {
 	return nil, nil
 }
 func (f *fakeDBLease) CheckIfAllTasksDone(ctx context.Context, dagRunID int) (bool, error) {
@@ -100,6 +104,9 @@ func (f *fakeDBLease) DagrunExists(ctx context.Context, dagrunId int) (bool, err
 }
 func (f *fakeDBLease) GetTaskRunInfo(ctx context.Context, taskRunId int) (dagName, taskName, namespace string, err error) {
 	return "d", "t", "ns", nil
+}
+func (f *fakeDBLease) TaskRunExists(ctx context.Context, runId, dagTaskId int) (bool, error) {
+	return false, nil
 }
 
 // Claim/lease primitives

--- a/controller/internal/workers/worker_run_test.go
+++ b/controller/internal/workers/worker_run_test.go
@@ -107,6 +107,9 @@ func (f *fakeDB) DagrunExists(ctx context.Context, dagrunId int) (bool, error) {
 func (f *fakeDB) GetTaskRunInfo(ctx context.Context, taskRunId int) (dagName, taskName, namespace string, err error) {
 	return "d", "t", "ns", nil
 }
+func (f *fakeDB) TaskRunExists(ctx context.Context, runId, dagTaskId int) (bool, error) {
+	return false, nil
+}
 
 // Claim and lease primitives (no-op stubs for worker tests)
 func (f *fakeDB) ClaimTasks(ctx context.Context, limit int, workerId string, leaseTTL time.Duration) ([]db.TaskClaim, error) {

--- a/controller/test/integration/workerpool_integration.sh
+++ b/controller/test/integration/workerpool_integration.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Integration test for WorkerPool using kind
+# Requirements: kind, kubectl, helm, kustomize, docker
+# Run from repository root: ./controller/test/integration/workerpool_integration.sh
+
+KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-kind}
+NAMESPACE=default
+WP_NAME=integration-wp
+DEP_NAME=${WP_NAME}-workers
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+WORKER_TEST_TAG=${WORKER_TEST_TAG:-itest}
+WORKER_TEST_IMAGE="greedykomodo/kontroler-worker:${WORKER_TEST_TAG}"
+
+wait_for_rollout() {
+  ns="$1"
+  deploy="$2"
+  timeout="${3:-180s}"
+  kubectl -n "$ns" rollout status deployment/"$deploy" --timeout="$timeout"
+}
+
+wait_for_webhook_service() {
+  echo "==> Waiting for operator-webhook-service endpoints"
+  for i in {1..60}; do
+    ep=$(kubectl -n operator-system get endpoints operator-webhook-service -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null || true)
+    if [ -n "$ep" ]; then
+      echo "Webhook endpoint ready at $ep"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "ERROR: operator-webhook-service has no ready endpoints"
+  return 1
+}
+
+wait_for_webhook_cabundle() {
+  echo "==> Waiting for webhook CA bundle injection"
+  for i in {1..60}; do
+    out=$(kubectl get mutatingwebhookconfiguration operator-mutating-webhook-configuration -o jsonpath='{.webhooks[0].clientConfig.caBundle}' 2>/dev/null || true)
+    if [ -n "$out" ]; then
+      echo "CA bundle injected"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "ERROR: CA bundle was not injected in time"
+  return 1
+}
+
+check_admission_ready() {
+  echo "==> Checking admission webhook readiness with server dry-run"
+  tmp=$(mktemp -t dagrun-dryrun-XXXX.yaml)
+  cat > "$tmp" <<EOF
+apiVersion: kontroler.greedykomodo/v1alpha1
+kind: DagRun
+metadata:
+  name: dryrun-check
+  namespace: ${NAMESPACE}
+spec:
+  dagName: dryrun-dag
+EOF
+  if kubectl apply --dry-run=server -f "$tmp" >/dev/null 2>&1; then
+    echo "Admission webhook is reachable"
+    rm -f "$tmp"
+    return 0
+  fi
+  echo "ERROR: admission webhook dry-run failed"
+  kubectl apply --dry-run=server -f "$tmp" || true
+  rm -f "$tmp"
+  return 1
+}
+
+set_deployment_ready_replicas() {
+  ns="$1"; name="$2"; val="$3"
+  if kubectl -n "$ns" patch deployment "$name" --type='merge' --subresource=status -p "{\"status\":{\"readyReplicas\":$val}}" 2>/dev/null; then
+    return 0
+  fi
+  if kubectl -n "$ns" get deployment "$name" -o json > /tmp/dep.json 2>/dev/null; then
+    python3 - <<PY > /tmp/dep2.json
+import sys, json
+obj = json.load(sys.stdin)
+obj.setdefault('status', {})['readyReplicas'] = int("$val")
+json.dump(obj, sys.stdout)
+PY
+    kubectl replace --raw "/apis/apps/v1/namespaces/$ns/deployments/$name/status" -f /tmp/dep2.json >/dev/null 2>&1 && return 0
+  fi
+  echo "Warning: couldn't patch deployment status to readyReplicas=$val; continuing"
+  return 1
+}
+
+echo "==> Creating kind cluster '${KIND_CLUSTER_NAME}'"
+kind create cluster --name "${KIND_CLUSTER_NAME}" || true
+
+echo "==> Building and loading controller image into kind"
+make -C controller docker-build
+make -C controller kind-load-controller
+
+echo "==> Building and loading worker image into kind"
+make -C controller docker-build-worker
+# Tag worker image with non-latest tag to avoid implicit Always pull policy
+if docker image inspect greedykomodo/kontroler-worker:latest >/dev/null 2>&1; then
+  docker tag greedykomodo/kontroler-worker:latest "${WORKER_TEST_IMAGE}"
+fi
+kind load docker-image "${WORKER_TEST_IMAGE}" --name "${KIND_CLUSTER_NAME}"
+
+# Ensure operator namespace exists
+kubectl create ns operator-system || true
+
+# Avoid deleting CRDs mid-run; Helm handles upgrades/install ownership.
+# (Deleting CRDs here can put them into Terminating while tests are running.)
+
+# Install cert-manager (chart-managed webhook certs)
+if ! kubectl -n cert-manager get deployment cert-manager >/dev/null 2>&1; then
+  echo "==> Installing cert-manager via Helm"
+  helm repo add jetstack https://charts.jetstack.io >/dev/null 2>&1 || true
+  helm repo update >/dev/null 2>&1 || true
+  helm upgrade --install cert-manager jetstack/cert-manager \
+    --namespace cert-manager --create-namespace \
+    --set crds.enabled=true \
+    --wait --timeout 5m
+fi
+
+# Create test secrets the chart expects (idempotent)
+if ! kubectl -n operator-system get secret postgresql-client-tls >/dev/null 2>&1; then
+  echo "==> Creating dummy postgresql-client-tls secret"
+  kubectl -n operator-system create secret generic postgresql-client-tls --from-literal=ca.crt='dummy-ca' --from-literal=client.crt='dummy-client' --from-literal=client.key='dummy-key' >/dev/null
+fi
+
+if ! kubectl -n operator-system get secret jwt-kontroller-key >/dev/null 2>&1; then
+  echo "==> Creating dummy jwt-kontroller-key secret"
+  kubectl -n operator-system create secret generic jwt-kontroller-key --from-literal=jwt='dummyjwt' >/dev/null
+fi
+
+if ! kubectl -n operator-system get secret kontroler-db-secret >/dev/null 2>&1; then
+  echo "==> Creating DB secret"
+  kubectl -n operator-system create secret generic kontroler-db-secret --from-literal=password=postgres >/dev/null
+fi
+
+# Deploy Postgres
+if ! helm ls -q | rg -x "postgres" >/dev/null 2>&1; then
+  echo "==> Deploying test Postgres via Helm"
+  helm repo add bitnami https://charts.bitnami.com/bitnami >/dev/null 2>&1 || true
+  helm upgrade --install postgres bitnami/postgresql \
+    --set auth.postgresPassword=postgres \
+    --set primary.persistence.enabled=false \
+    --wait --timeout 5m
+fi
+kubectl -n default rollout status statefulset/postgres-postgresql --timeout=180s
+
+# Ensure kontroler DB exists
+bash "$ROOT_DIR/scripts/kind-create-db.sh"
+
+# Copy DB password secret into operator-system
+kubectl -n operator-system create secret generic postgres-postgresql --from-literal=postgres-password=postgres --dry-run=client -o yaml | kubectl apply -f -
+
+# Install chart
+helm upgrade --install kontroler "$ROOT_DIR/../helm/kontroler" \
+  --namespace operator-system --create-namespace \
+  --set crds.install=true \
+  --set certManager.enabled=true \
+  --set webhook.enabled=true \
+  --set controller.image=greedykomodo/kontroler-controller:0.0.1 \
+  --set controller.enabled=true \
+  --set server.enabled=false \
+  --set ui.enabled=false \
+  --set db.type=postgresql \
+  --set db.postgresql.endpoint=postgres-postgresql.default.svc.cluster.local:5432 \
+  --set controller.db.ssl.mode=disable \
+  --set controller.db.password.secret=postgres-postgresql \
+  --set controller.db.password.key=postgres-password \
+  --wait --timeout 5m
+
+# Wait for manager deployment (correct name)
+wait_for_rollout operator-system kontroler-manager 180s
+wait_for_webhook_cabundle
+wait_for_webhook_service
+check_admission_ready
+
+# create WorkerPool manifest
+WP_MANIFEST=$(mktemp -t workerpool-XXXX.yaml)
+cat > "$WP_MANIFEST" <<EOF
+apiVersion: kontroler.greedykomodo/v1alpha1
+kind: WorkerPool
+metadata:
+  name: ${WP_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  image: ${WORKER_TEST_IMAGE}
+  podTemplate:
+    serviceAccountName: default
+    nodeSelector:
+      node-role.kubernetes.io/worker: "true"
+  gracefulShutdownSeconds: 30
+EOF
+
+echo "==> Creating WorkerPool"
+kubectl apply -f "$WP_MANIFEST"
+kubectl label node kind-control-plane node-role.kubernetes.io/worker=true --overwrite || true
+
+echo "==> Waiting for generated Deployment to appear"
+for i in {1..60}; do
+  if kubectl -n ${NAMESPACE} get deployment ${DEP_NAME} >/dev/null 2>&1; then
+    echo "Deployment ${DEP_NAME} created"
+    break
+  fi
+  sleep 2
+done
+
+echo "==> Waiting for worker pod to become Running"
+for i in {1..60}; do
+  POD=$(kubectl -n ${NAMESPACE} get pods -l workerpool=${WP_NAME} -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  if [ -n "$POD" ]; then
+    PHASE=$(kubectl -n ${NAMESPACE} get pod "$POD" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    if [ "$PHASE" = "Running" ]; then
+      echo "Worker pod $POD is Running"
+      break
+    fi
+  fi
+  sleep 2
+done
+
+# simulate ready replica for finalizer flow
+set_deployment_ready_replicas ${NAMESPACE} ${DEP_NAME} 1 || true
+
+# DAG + DagRun
+DAG_MANIFEST=$(mktemp -t dag-XXXX.yaml)
+cat > "$DAG_MANIFEST" <<EOF
+apiVersion: kontroler.greedykomodo/v1alpha1
+kind: DAG
+metadata:
+  name: e2e-sample
+  namespace: ${NAMESPACE}
+spec:
+  schedule: ""
+  task:
+    - name: say-hello
+      command: ["sh", "-c"]
+      args: ["echo hello from task && sleep 1"]
+      image: alpine:3.18
+      backoff:
+        limit: 0
+EOF
+kubectl apply -f "$DAG_MANIFEST"
+sleep 2
+kubectl -n ${NAMESPACE} delete dagrun e2e-sample-run --ignore-not-found
+
+DAGRUN_MANIFEST=$(mktemp -t dagrun-XXXX.yaml)
+cat > "$DAGRUN_MANIFEST" <<EOF
+apiVersion: kontroler.greedykomodo/v1alpha1
+kind: DagRun
+metadata:
+  name: e2e-sample-run
+  namespace: ${NAMESPACE}
+spec:
+  dagName: e2e-sample
+EOF
+
+kubectl apply -f "$DAGRUN_MANIFEST"
+
+echo "==> Waiting for task pod created by scheduler"
+POD_NAME=""
+for i in {1..90}; do
+  POD_NAME=$(kubectl -n ${NAMESPACE} get pods -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.containers[0].image}{"\n"}{end}' | awk '$2 ~ /alpine/ {print $1; exit}')
+  if [ -n "${POD_NAME}" ]; then
+    echo "Found task pod: ${POD_NAME}"
+    break
+  fi
+  sleep 2
+done
+
+if [ -n "${POD_NAME}" ]; then
+  kubectl -n ${NAMESPACE} wait --for=condition=Succeeded pod/${POD_NAME} --timeout=120s || true
+  echo "==> Task pod logs:"
+  kubectl -n ${NAMESPACE} logs ${POD_NAME} || true
+else
+  echo "Warning: could not find task pod running alpine image"
+fi
+
+# delete WorkerPool
+kubectl delete workerpool ${WP_NAME} -n ${NAMESPACE} || true
+
+echo "==> Waiting for controller to scale Deployment to 0 replicas (or remove it)"
+for i in {1..30}; do
+  if ! kubectl -n ${NAMESPACE} get deployment ${DEP_NAME} >/dev/null 2>&1; then
+    echo "Deployment removed"
+    break
+  fi
+  REPLICAS=$(kubectl -n ${NAMESPACE} get deployment ${DEP_NAME} -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+  if [ "$REPLICAS" = "0" ]; then
+    echo "Deployment scaled to 0"
+    break
+  fi
+  sleep 2
+done
+
+if kubectl -n ${NAMESPACE} get deployment ${DEP_NAME} >/dev/null 2>&1; then
+  set_deployment_ready_replicas ${NAMESPACE} ${DEP_NAME} 0 || true
+fi
+
+echo "==> Waiting for WorkerPool deletion"
+for i in {1..30}; do
+  if ! kubectl -n ${NAMESPACE} get workerpool ${WP_NAME} >/dev/null 2>&1; then
+    echo "WorkerPool deleted"
+    break
+  fi
+  sleep 2
+done
+
+# cleanup
+echo "==> Cleaning up"
+helm -n operator-system uninstall kontroler || true
+kubectl delete crd workerpools.kontroler.greedykomodo || true
+kubectl -n operator-system delete secret webhook-server-cert kontroler-db-secret postgresql-client-tls jwt-kontroller-key --ignore-not-found || true
+
+rm -f "$WP_MANIFEST" "$DAG_MANIFEST" "$DAGRUN_MANIFEST"
+echo "==> Integration test completed"

--- a/helm/kontroler/templates/controller/crdRole.yaml
+++ b/helm/kontroler/templates/controller/crdRole.yaml
@@ -22,6 +22,57 @@ rules:
 - apiGroups:
   - kontroler.greedykomodo
   resources:
+  - workerpools
+  - workerpools/status
+  - workerpools/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kontroler.greedykomodo
+  resources:
   - dagruns/finalizers
   verbs:
   - update

--- a/helm/kontroler/templates/controller/podRole.yaml
+++ b/helm/kontroler/templates/controller/podRole.yaml
@@ -25,6 +25,12 @@ rules:
   verbs:
   - get
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/kontroler/templates/crds/workerpools.yaml
+++ b/helm/kontroler/templates/crds/workerpools.yaml
@@ -1,0 +1,63 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workerpools.kontroler.greedykomodo
+spec:
+  group: kontroler.greedykomodo
+  names:
+    kind: WorkerPool
+    plural: workerpools
+    singular: workerpool
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                image:
+                  type: string
+                concurrency:
+                  type: object
+                  properties:
+                    maxConcurrentClaims:
+                      type: integer
+                    claimBatchSize:
+                      type: integer
+                lease:
+                  type: object
+                  properties:
+                    ttlSeconds:
+                      type: integer
+                podTemplate:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                dbSecretRef:
+                  type: string
+                metrics:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                    scrapePort:
+                      type: integer
+                gracefulShutdownSeconds:
+                  type: integer
+            status:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                readyReplicas:
+                  type: integer
+                lastReconcileTime:
+                  type: string
+      subresources:
+        status: {}

--- a/helm/kontroler/values.yaml
+++ b/helm/kontroler/values.yaml
@@ -8,12 +8,12 @@ nameOverride: ""
 fullnameOverride: ""
 
 crds:
-  install: true
+  install: false
   retain: false
 
 db:
   # sqlite or postgresql
-  type: sqlite
+  type: postgresql
   sqlite:
     path: /data
     fileName: database.db
@@ -218,7 +218,6 @@ server:
   jwt:
     secret: jwt-kontroller-key
     key: jwt
-  imagePullPolicy: Always
   # Assumes some local port forwarding is being applied
   uiAddress: http://localhost:3000
   auditLogs: true


### PR DESCRIPTION
This pull request introduces the initial implementation of the WorkerPool controller and its supporting infrastructure, enabling the management and orchestration of worker pods via a new custom resource. The changes include the definition of the `WorkerPool` CRD and its Go types, a sample worker binary and Dockerfile, RBAC updates, Makefile targets, and a sample manifest. These updates lay the foundation for scalable, configurable worker pools in the system.

**WorkerPool CRD and Controller Implementation:**

* Added the `WorkerPool` CustomResourceDefinition (`controller/config/crd/bases/kontroler.greedykomodo_workerpools.yaml`) and corresponding Go type definitions in `workerpool_types.go`, specifying configuration fields for replicas, image, concurrency, leases, pod template, DB secrets, metrics, and graceful shutdown. [[1]](diffhunk://#diff-2b6e63f15a499036598db289bf6a619132d175d9e7615623a7b04f8b41e866f6R1-R63) [[2]](diffhunk://#diff-75c7168a7e629f715d94e2e8c1b571df002056701fa8fd8722a610a73c08ada5R1-R130)
* Implemented the `ensureWorkerRBAC` helper in `workerpool_rbac.go` to automate creation and management of ServiceAccounts, Roles, and RoleBindings for each `WorkerPool`, ensuring proper pod and exec permissions.

**Worker Binary and Build Infrastructure:**

* Introduced a minimal worker binary in `cmd/worker/main.go` that connects to the database, sets up logging, handles signals, and runs the worker event loop.
* Added `Dockerfile.worker` for building and packaging the worker binary using a distroless base image, and new Makefile targets for building, loading, and testing the worker image with kind (`docker-build-worker`, `kind-load-worker`, `kind-integration-workerpool`). [[1]](diffhunk://#diff-c20bd2d747d214f0c75c4a10f13fd6e3d43ca049da53c98fab874e332170135dR1-R14) [[2]](diffhunk://#diff-279fcdaea13644458ae659d7ea2138133ebb5a9d822fc36b45c2bfc7bb71d7a8R191-R208)

**RBAC and Sample Manifest Updates:**

* Updated RBAC rules in `role.yaml` to grant the controller permissions to manage Deployments, Pods, ServiceAccounts, Roles, RoleBindings, and the new `WorkerPool` resources. [[1]](diffhunk://#diff-53a06655a33c71682570746c3572dea00563b8b50654350c9de7f6c351d299b0R7-R61) [[2]](diffhunk://#diff-53a06655a33c71682570746c3572dea00563b8b50654350c9de7f6c351d299b0R140-R159)
* Added a sample `WorkerPool` manifest in `kontroler_v1alpha1_workerpool.yaml` demonstrating how to deploy a worker pool with a custom image and pod template.…lean branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `WorkerPool` custom resource enabling declarative management of distributed workers in Kubernetes
  * Added worker controller for automatic deployment creation, scaling, and graceful shutdown of worker instances
  * Implemented RBAC role provisioning for secure worker pod execution and management
  * Changed default database backend from SQLite to PostgreSQL for improved scalability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->