### PR TITLE
docs: add example DAG manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Planned Features:
 
 Here are two examples, one event-driven & one that runs on a schedule:
 
+Canonical manifests for the README examples live in [`examples/`](examples/).
+See [`examples/README.md`](examples/README.md) for a short QuickStart that shows
+how to apply the DAG and DagRun manifests with `kubectl`.
+
 Event Driven
 ```yaml
 apiVersion: kontroler.greedykomodo/v1alpha1

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,46 @@
+# Kontroler examples
+
+This directory contains copy/pasteable manifests that mirror the README DAG
+examples.
+
+## Prerequisites
+
+- A Kubernetes cluster with Kontroler installed
+- `kubectl` configured for that cluster
+
+If you are running Kontroler from source, install the CRDs before applying these
+examples:
+
+```sh
+cd controller
+make install
+```
+
+## Apply an example DAG
+
+From the repository root:
+
+```sh
+kubectl apply -f examples/dag-event-driven.yaml
+kubectl apply -f examples/dag-schedule.yaml
+kubectl apply -f examples/dag-dsl-example.yaml
+```
+
+## Start a DAG run manually
+
+The sample `DagRun` references `dag-schedule`, which is defined in
+`dag-schedule.yaml`.
+
+```sh
+kubectl apply -f examples/dagrun-sample.yaml
+kubectl get dagruns
+```
+
+## Clean up
+
+```sh
+kubectl delete -f examples/dagrun-sample.yaml --ignore-not-found
+kubectl delete -f examples/dag-dsl-example.yaml --ignore-not-found
+kubectl delete -f examples/dag-schedule.yaml --ignore-not-found
+kubectl delete -f examples/dag-event-driven.yaml --ignore-not-found
+```

--- a/examples/dag-dsl-example.yaml
+++ b/examples/dag-dsl-example.yaml
@@ -1,0 +1,30 @@
+apiVersion: kontroler.greedykomodo/v1alpha1
+kind: DAG
+metadata:
+  name: dag-dsl-example
+spec:
+  dsl: |
+    schedule "*/5 * * * *"
+
+    graph {
+      start -> process -> finish
+    }
+
+    task start {
+      image "alpine:latest"
+      script "echo 'Starting job'"
+      backoff 3
+    }
+
+    task process {
+      image "alpine:latest"
+      script "echo 'Processing data'"
+      backoff 3
+      retry [1, 2]
+    }
+
+    task finish {
+      image "alpine:latest"
+      script "echo 'Job completed'"
+      backoff 3
+    }

--- a/examples/dag-event-driven.yaml
+++ b/examples/dag-event-driven.yaml
@@ -1,0 +1,26 @@
+apiVersion: kontroler.greedykomodo/v1alpha1
+kind: DAG
+metadata:
+  name: event-driven
+spec:
+  schedule: ""
+  task:
+    - name: "start"
+      command: ["sh", "-c"]
+      args: ["echo 'event-driven DAG started'"]
+      image: "alpine:latest"
+      backoff:
+        limit: 3
+      conditional:
+        enabled: false
+        retryCodes: []
+    - name: "finish"
+      command: ["sh", "-c"]
+      args: ["echo 'event-driven DAG finished'"]
+      image: "alpine:latest"
+      runAfter: ["start"]
+      backoff:
+        limit: 3
+      conditional:
+        enabled: false
+        retryCodes: []

--- a/examples/dag-schedule.yaml
+++ b/examples/dag-schedule.yaml
@@ -1,0 +1,36 @@
+apiVersion: kontroler.greedykomodo/v1alpha1
+kind: DAG
+metadata:
+  name: dag-schedule
+spec:
+  schedule: "*/1 * * * *"
+  task:
+    - name: "random"
+      command: ["sh", "-c"]
+      args: ["echo 'Hello, World!'"]
+      image: "alpine:latest"
+      backoff:
+        limit: 3
+      conditional:
+        enabled: true
+        retryCodes: [8]
+    - name: "random-b"
+      command: ["sh", "-c"]
+      args: ["echo 'Hello, World!'"]
+      image: "alpine:latest"
+      runAfter: ["random"]
+      backoff:
+        limit: 3
+      conditional:
+        enabled: true
+        retryCodes: [8]
+    - name: "random-c"
+      command: ["sh", "-c"]
+      args: ["echo 'Hello, World!'"]
+      image: "alpine:latest"
+      runAfter: ["random"]
+      backoff:
+        limit: 3
+      conditional:
+        enabled: true
+        retryCodes: [8]

--- a/examples/dagrun-sample.yaml
+++ b/examples/dagrun-sample.yaml
@@ -1,0 +1,7 @@
+apiVersion: kontroler.greedykomodo/v1alpha1
+kind: DagRun
+metadata:
+  name: dagrun-sample
+spec:
+  dagName: dag-schedule
+  parameters: []


### PR DESCRIPTION
## Summary
- add top-level `examples/` manifests for the README's event-driven, scheduled, and DSL DAG examples
- add a sample `DagRun` manifest that targets `dag-schedule`
- add an `examples/README.md` QuickStart with apply and cleanup commands
- link the examples directory from the root README

Fixes #185

## Validation
- `git diff HEAD^..HEAD --check`
- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' examples/*.yaml`
- `kubectl apply --dry-run=client --validate=false -f examples/` was attempted locally and failed because the current cluster does not have the Kontroler CRDs installed. The QuickStart now calls out installing the CRDs first with `cd controller && make install`.

## Notes
- The examples keep the README names and concepts, but avoid optional external secrets/PVCs/imagePullSecrets so they are easier to copy and apply against a fresh Kontroler install.
